### PR TITLE
Change main classes to hold module instances instead of implementing wrapper methods

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,579 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        missing-docstring,
+        invalid-name,
+        duplicate-code
+
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: en_NZ (myspell), en_BZ
+# (myspell), en_BS (myspell), en_PH (myspell), en_IE (myspell), en_MW
+# (myspell), en_IN (myspell), en_AU (myspell), en_BW (myspell), en_GB
+# (myspell), en_CA (myspell), en_HK (myspell), en_GH (myspell), en_US
+# (myspell), en_ZM (myspell), en_SG (myspell), en_NA (myspell), en_NG
+# (myspell), en_AG (myspell), en_ZA (myspell), en_TT (myspell), en_JM
+# (myspell), en_ZW (myspell), en_DK (myspell)..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=LF
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=140
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=10
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=10
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/cterasdk/client/__init__.py
+++ b/cterasdk/client/__init__.py
@@ -1,1 +1,1 @@
-from .host import NetworkHost, CTERAHost  # noqa: E402, F401
+from .host import NetworkHost, CTERAHost, authenticated  # noqa: E402, F401

--- a/cterasdk/client/host.py
+++ b/cterasdk/client/host.py
@@ -73,6 +73,15 @@ class CTERAHost(NetworkHost):
         super().__init__(host, port, https)
         self._ctera_client = CTERAClient()
         self._session = None
+        self.login = self._login_object.login
+        self.logout = self._login_object.logout
+
+    @property
+    def _omit_fields(self):
+        return super()._omit_fields + [
+            'login',
+            'logout'
+        ]
 
     @property
     def base_api_url(self):
@@ -81,6 +90,12 @@ class CTERAHost(NetworkHost):
     @property
     def base_file_url(self):
         raise NotImplementedError("Implementing class must implement the base_api_url property")
+
+    @property
+    def _login_object(self):
+        raise NotImplementedError(
+            "Implementing class must implement the login_object property by returning an object with login and logout methods"
+        )
 
     def _is_authenticated(self, function, *args, **kwargs):
         raise NotImplementedError("Implementing class must implement the _is_authenticated method")

--- a/cterasdk/common/object.py
+++ b/cterasdk/common/object.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-instance-attributes
 import json
 
 

--- a/cterasdk/core/__init__.py
+++ b/cterasdk/core/__init__.py
@@ -7,7 +7,6 @@ __all__ = list(
             'directoryservice',
             'enum',
             'login',
-            'whoami',
             'query',
             'logs',
             'portals',

--- a/cterasdk/core/activation.py
+++ b/cterasdk/core/activation.py
@@ -1,18 +1,20 @@
 import logging
 
+from .base_command import BaseCommand
 from ..convert import tojsonstr
 
 
-def generate_code(ctera_host, username, tenant):
-    params = {'username': username}
+class Activation(BaseCommand):
+    def generate_code(self, username, tenant):
+        params = {'username': username}
 
-    if tenant is not None:
-        params['portal'] = tenant
+        if tenant is not None:
+            params['portal'] = tenant
 
-    logging.getLogger().info('Generating device activation code. %s', {'user': username, 'portal': tenant})
+        logging.getLogger().info('Generating device activation code. %s', {'user': username, 'portal': tenant})
 
-    response = ctera_host.get('/ssoActivation', params)
+        response = self._portal.get('/ssoActivation', params)
 
-    logging.getLogger().info('Generated device activation code. %s', tojsonstr(response, False))
+        logging.getLogger().info('Generated device activation code. %s', tojsonstr(response, False))
 
-    return response.code
+        return response.code

--- a/cterasdk/core/base_command.py
+++ b/cterasdk/core/base_command.py
@@ -1,0 +1,7 @@
+class BaseCommand:
+
+    def __init__(self, portal):
+        self._portal = portal
+
+    def session(self):
+        return self._portal.session()

--- a/cterasdk/core/decorator.py
+++ b/cterasdk/core/decorator.py
@@ -1,25 +1,6 @@
 import functools
 import logging
 
-from ..exception import CTERAException
-
-
-def authenticated(function):
-
-    @functools.wraps(function)
-    def check_authenticated_and_call(self, *args):
-        session = self.session()
-        if session.authenticated():
-            return function(self, *args)
-
-        if session.initializing():
-            return function(self, *args)
-
-        logging.getLogger().error('Not logged in.')
-        raise CTERAException('Not logged in')
-
-    return check_authenticated_and_call
-
 
 def update_current_tenant(function):
 

--- a/cterasdk/core/devices.py
+++ b/cterasdk/core/devices.py
@@ -1,63 +1,62 @@
+from .base_command import BaseCommand
 from .enum import DeviceType
 from . import remote, query, union
 from ..exception import CTERAException
 
-name_attr = 'name'
-type_attr = 'deviceType'
-default = ['name', 'portal', 'deviceType']
 
+class Devices(BaseCommand):
 
-def device(CTERAHost, device_name, include):
-    include = union.union(include, default)
-    include = ['/' + attr for attr in include]
-    tenant = CTERAHost.session().tenant()
-    url = '/portals/%s/devices/%s' % (tenant, device_name)
+    name_attr = 'name'
+    type_attr = 'deviceType'
+    default = ['name', 'portal', 'deviceType']
 
-    dev = CTERAHost.get_multi(url, include)
-    if dev.name is None:
-        raise CTERAException('Device not found', None, tenant=tenant, device=device_name)
+    def device(self, device_name, include=None):
+        include = union.union(include or [], Devices.default)
+        include = ['/' + attr for attr in include]
+        tenant = self._portal.session().tenant()
+        url = '/portals/%s/devices/%s' % (tenant, device_name)
 
-    return remote.remote_command(CTERAHost, dev)
+        dev = self._portal.get_multi(url, include)
+        if dev.name is None:
+            raise CTERAException('Device not found', None, tenant=tenant, device=device_name)
 
+        return remote.remote_command(self._portal, dev)
 
-def filers(CTERAHost, include, allPortals, deviceTypes):
-    deviceTypes = [deviceType for deviceType in deviceTypes if deviceType in DeviceType.Gateways]
-    if not deviceTypes:
-        deviceTypes = DeviceType.Gateways
+    def filers(self, include=None, allPortals=False, deviceTypes=None):
+        if deviceTypes:
+            deviceTypes = [deviceType for deviceType in deviceTypes if deviceType in DeviceType.Gateways]
+        if not deviceTypes:
+            deviceTypes = DeviceType.Gateways
 
-    filters = [query.FilterBuilder(type_attr).eq(deviceType) for deviceType in deviceTypes]
-    return devices(CTERAHost, include, allPortals, filters)
+        filters = [query.FilterBuilder(Devices.type_attr).eq(deviceType) for deviceType in deviceTypes]
+        return self.devices(include, allPortals, filters)
 
+    def agents(self, include=None, allPortals=False):
+        filters = [query.FilterBuilder(Devices.type_attr).like('Agent')]
+        return self.devices(include, allPortals, filters)
 
-def agents(CTERAHost, include, allPortals):
-    filters = [query.FilterBuilder(type_attr).like('Agent')]
-    return devices(CTERAHost, include, allPortals, filters)
+    def desktops(self, include=None, allPortals=False):
+        filters = [query.FilterBuilder(Devices.type_attr).eq(DeviceType.WorkstationAgent)]
+        return self.devices(include, allPortals, filters)
 
+    def servers(self, include=None, allPortals=False):
+        filters = [query.FilterBuilder(Devices.type_attr).eq(DeviceType.ServerAgent)]
+        return self.devices(include, allPortals, filters)
 
-def desktops(CTERAHost, include, allPortals):
-    filters = [query.FilterBuilder(type_attr).eq(DeviceType.WorkstationAgent)]
-    return devices(CTERAHost, include, allPortals, filters)
+    def by_name(self, names, include=None):
+        filters = [query.FilterBuilder('name').eq(name) for name in names]
+        return self.devices(include, False, filters)
 
+    def devices(self, include=None, allPortals=False, filters=None):
+        include = union.union(include or [], Devices.default)
+        builder = query.QueryParamBuilder().include(include).allPortals(allPortals)
+        filters = filters or []
+        for query_filter in filters:
+            builder.addFilter(query_filter)
+        builder.orFilter((len(filters) > 1))
+        param = builder.build()
 
-def servers(CTERAHost, include, allPortals):
-    filters = [query.FilterBuilder(type_attr).eq(DeviceType.ServerAgent)]
-    return devices(CTERAHost, include, allPortals, filters)
-
-
-def by_name(CTERAHost, include, names):
-    filters = [query.FilterBuilder('name').eq(name) for name in names]
-    return devices(CTERAHost, include, False, filters)
-
-
-def devices(CTERAHost, include, allPortals, filters):
-    include = union.union(include, default)
-    builder = query.QueryParamBuilder().include(include).allPortals(allPortals)
-    for query_filter in filters:
-        builder.addFilter(query_filter)
-    builder.orFilter((len(filters) > 1))
-    param = builder.build()
-
-    # Check if the _all attribute conflicts with the current tenant
-    iterator = CTERAHost.iterator('/devices', param)
-    for dev in iterator:
-        yield remote.remote_command(CTERAHost, dev)
+        # Check if the _all attribute conflicts with the current tenant
+        iterator = query.iterator(self._portal, '/devices', param)
+        for dev in iterator:
+            yield remote.remote_command(self._portal, dev)

--- a/cterasdk/core/directoryservice.py
+++ b/cterasdk/core/directoryservice.py
@@ -1,80 +1,83 @@
 import logging
 
+from .base_command import BaseCommand
 from ..common import Object
 from ..exception import CTERAException, InputError
 from .enum import ActiveDirectoryAccountType, SearchType
 
 
-def fetch(ctera_host, tuples):
-    domains = ctera_host.domains()
-    account_types = [v for k, v in ActiveDirectoryAccountType.__dict__.items() if not k.startswith('_')]
+class DirectoryService(BaseCommand):
 
-    param = []
-    for entry in tuples:
-        if len(entry) != 3:
-            logging.getLogger().error('Invalid entry length.')
-            raise InputError('Invalid entry', entry, '[("domain", "account_type", "account_name"), ...]')
+    def fetch(self, tuples):
+        domains = self._portal.users.domains()
+        account_types = [v for k, v in ActiveDirectoryAccountType.__dict__.items() if not k.startswith('_')]
 
-        domain, account_type, name = entry
-        if domain not in domains:
-            logging.getLogger().error('Invalid domain name. %s', {'domain': domain})
-            raise CTERAException('Invalid domain', None, domain=domain, domains=domains)
+        param = []
+        for entry in tuples:
+            if len(entry) != 3:
+                logging.getLogger().error('Invalid entry length.')
+                raise InputError('Invalid entry', entry, '[("domain", "account_type", "account_name"), ...]')
 
-        if account_type not in account_types:
-            logging.getLogger().error('Invalid account type. %s', {'type': account_type})
-            raise CTERAException('Invalid account type', None, type=account_type, options=account_types)
+            domain, account_type, name = entry
+            if domain not in domains:
+                logging.getLogger().error('Invalid domain name. %s', {'domain': domain})
+                raise CTERAException('Invalid domain', None, domain=domain, domains=domains)
 
-    for domain, account_type, name in tuples:
-        if account_type == ActiveDirectoryAccountType.User:
-            param.append(search_users(ctera_host, domain, name))
-        elif account_type == ActiveDirectoryAccountType.Group:
-            param.append(search_groups(ctera_host, domain, name))
+            if account_type not in account_types:
+                logging.getLogger().error('Invalid account type. %s', {'type': account_type})
+                raise CTERAException('Invalid account type', None, type=account_type, options=account_types)
 
-    logging.getLogger().info('Starting to fetch users and groups.')
+        for domain, account_type, name in tuples:
+            if account_type == ActiveDirectoryAccountType.User:
+                param.append(self._search_users(domain, name))
+            elif account_type == ActiveDirectoryAccountType.Group:
+                param.append(self._search_groups(domain, name))
 
-    response = ctera_host.execute('', 'syncAD', param)
+        logging.getLogger().info('Starting to fetch users and groups.')
 
-    logging.getLogger().info('Started fetching users and groups.')
+        response = self._portal.execute('', 'syncAD', param)
 
-    return response
+        logging.getLogger().info('Started fetching users and groups.')
 
+        return response
 
-def search_users(ctera_host, domain, user):
-    return search_directory_services(ctera_host, SearchType.Users, domain, user)
+    def _search_users(self, domain, user):
+        return self._search_directory_services(SearchType.Users, domain, user)
 
+    def _search_groups(self, domain, group):
+        return self._search_directory_services(SearchType.Groups, domain, group)
 
-def search_groups(ctera_host, domain, group):
-    return search_directory_services(ctera_host, SearchType.Groups, domain, group)
+    def _search_directory_services(self, search_type, domain, name):
+        param = Object()
+        param.mode = search_type
+        param.name = name
+        param.domain = domain
 
+        logging.getLogger().info(
+            'Searching %(search_type)s: %(info)s',
+            dict(search_type=search_type, info={'domain': domain, 'name': name})
+        )
 
-def search_directory_services(ctera_host, search_type, domain, name):
-    param = Object()
-    param.mode = search_type
-    param.name = name
-    param.domain = domain
+        objects = self._portal.execute('', 'searchAD', param)
+        if not objects:
+            logging.getLogger().info('Could not find results that match your search criteria. %s', {'domain': domain, 'name': name})
+            raise CTERAException(
+                'Could not find results that match your search criteria',
+                None,
+                domain=domain,
+                type=search_type,
+                account=name
+            )
 
-    logging.getLogger().info('Searching %(search_type)s: %(info)s', dict(search_type=search_type, info={'domain': domain, 'name': name}))
+        for principal in objects:
+            if principal.name == name:
+                logging.getLogger().info('Found. %s', {'domain': domain, 'name': name})
+                return principal
 
-    objects = ctera_host.execute('', 'searchAD', param)
-    if not objects:
-        logging.getLogger().info('Could not find results that match your search criteria. %s', {'domain': domain, 'name': name})
         raise CTERAException(
-            'Could not find results that match your search criteria',
+            'Search returned multiple results, but none that match your search criteria',
             None,
             domain=domain,
             type=search_type,
             account=name
         )
-
-    for principal in objects:
-        if principal.name == name:
-            logging.getLogger().info('Found. %s', {'domain': domain, 'name': name})
-            return principal
-
-    raise CTERAException(
-        'Search returned multiple results, but none that match your search criteria',
-        None,
-        domain=domain,
-        type=search_type,
-        account=name
-    )

--- a/cterasdk/core/files/browser.py
+++ b/cterasdk/core/files/browser.py
@@ -1,24 +1,24 @@
 from .path import CTERAPath
 
+from ..base_command import BaseCommand
 from . import ls, dl, directory, rename, rm, recover, mv, cp, ln
 
-# from . import List, Download, Directory, Rename, Delete, Recover, Move, Copy, Link
 
+class FileBrowser(BaseCommand):
 
-class FileBrowser:
-
-    def __init__(self, Portal):
-        self._CTERAHost = Portal
+    def __init__(self, portal, base_path):
+        super().__init__(portal)
+        self._base_path = base_path
 
     def ls(self, path):
-        return ls.ls(self._CTERAHost, self.mkpath(path))
+        return ls.ls(self._portal, self.mkpath(path))
 
     def walk(self, path):
         paths = [self.mkpath(path)]
 
         while len(paths) > 0:
             path = paths.pop(0)
-            items = ls.ls(self._CTERAHost, path)
+            items = ls.ls(self._portal, path)
             for item in items:
                 if item.isFolder:
                     paths.append(self.mkpath(item))
@@ -26,46 +26,42 @@ class FileBrowser:
 
     def download(self, path):
         path = self.mkpath(path)
-        dl.download(self._CTERAHost, path, path.name())
+        dl.download(self._portal, path, path.name())
 
     def mkdir(self, path, recurse=False):
-        directory.mkdir(self._CTERAHost, self.mkpath(path), recurse)
+        directory.mkdir(self._portal, self.mkpath(path), recurse)
 
     def rename(self, path, name):
-        return rename.rename(self._CTERAHost, self.mkpath(path), name)
+        return rename.rename(self._portal, self.mkpath(path), name)
 
     def delete(self, path):
-        return rm.delete(self._CTERAHost, self.mkpath(path))
+        return rm.delete(self._portal, self.mkpath(path))
 
     def delete_multi(self, *args):
-        return rm.delete_multi(self._CTERAHost, *self.mkpath(list(args)))
+        return rm.delete_multi(self._portal, *self.mkpath(list(args)))
 
     def undelete(self, path):
-        return recover.undelete(self._CTERAHost, self.mkpath(path))
+        return recover.undelete(self._portal, self.mkpath(path))
 
     def undelete_multi(self, *args):
-        return recover.undelete_multi(self._CTERAHost, *self.mkpath(list(args)))
+        return recover.undelete_multi(self._portal, *self.mkpath(list(args)))
 
     def move(self, src, dest):
-        return mv.move(self._CTERAHost, self.mkpath(src), self.mkpath(dest))
+        return mv.move(self._portal, self.mkpath(src), self.mkpath(dest))
 
     def move_multi(self, src, dest):
-        return mv.move_multi(self._CTERAHost, self.mkpath(src), self.mkpath(dest))
+        return mv.move_multi(self._portal, self.mkpath(src), self.mkpath(dest))
 
     def copy(self, src, dest):
-        return cp.copy(self._CTERAHost, self.mkpath(src), self.mkpath(dest))
+        return cp.copy(self._portal, self.mkpath(src), self.mkpath(dest))
 
     def copy_multi(self, src, dest):
-        return cp.copy_multi(self._CTERAHost, self.mkpath(src), self.mkpath(dest))
+        return cp.copy_multi(self._portal, self.mkpath(src), self.mkpath(dest))
 
     def mklink(self, path, access='RO', expire_in=30):
-        return ln.mklink(self._CTERAHost, self.mkpath(path), access, expire_in)
+        return ln.mklink(self._portal, self.mkpath(path), access, expire_in)
 
     def mkpath(self, array):
-        basepath = self._files()
         if isinstance(array, list):
-            return [CTERAPath(item, basepath) for item in array]
-        return CTERAPath(array, basepath)
-
-    def _files(self):
-        return self._CTERAHost._files()  # pylint: disable=protected-access
+            return [CTERAPath(item, self._base_path) for item in array]
+        return CTERAPath(array, self._base_path)

--- a/cterasdk/core/files/ln.py
+++ b/cterasdk/core/files/ln.py
@@ -9,7 +9,7 @@ def mklink(ctera_host, path, access, expire_in):
     expire_on = datetime.now() + timedelta(days=expire_in)
     expire_on = expire_on.strftime('%Y-%m-%d')
 
-    logging.getLogger().info('Creating public link. %s', {'path': path, 'access': access, 'expire_on': expire_on})
+    logging.getLogger().info('Creating public link. %s', {'path': str(path.relativepath), 'access': access, 'expire_on': expire_on})
 
     param = CreateShareParam.instance(path=path.fullpath(), access=access, expire_on=expire_on)
 

--- a/cterasdk/core/files/open.py
+++ b/cterasdk/core/files/open.py
@@ -3,4 +3,4 @@ import logging
 
 def openfile(ctera_host, path):
     logging.getLogger().info('Obtaining file handle. %s', {'path': str(path.relativepath)})
-    return ctera_host.openfile(ctera_host.baseurl(), path.fullpath(), params={})
+    return ctera_host.openfile(path.fullpath())

--- a/cterasdk/core/login.py
+++ b/cterasdk/core/login.py
@@ -1,19 +1,21 @@
 import logging
 
+from .base_command import BaseCommand
 from . import session
 
 
-def login(ctera_host, username, password):
-    ctera_host.form_data('/login', {'j_username': username, 'j_password': password})
+class Login(BaseCommand):
 
-    logging.getLogger().info("User logged in. %s", {'host': ctera_host.host(), 'user': username})
+    def login(self, username, password):
+        self._portal.form_data('/login', {'j_username': username, 'j_password': password})
 
-    session.activate(ctera_host)
+        logging.getLogger().info("User logged in. %s", {'host': self._portal.host(), 'user': username})
 
+        session.activate(self._portal)
 
-def logout(ctera_host):
-    ctera_host.form_data('/logout', {})
+    def logout(self):
+        self._portal.form_data('/logout', {})
 
-    logging.getLogger().info("User logged out. %s", {'host': ctera_host.host()})
+        logging.getLogger().info("User logged out. %s", {'host': self._portal.host()})
 
-    session.terminate(ctera_host)
+        session.terminate(self._portal)

--- a/cterasdk/core/query.py
+++ b/cterasdk/core/query.py
@@ -6,7 +6,7 @@ from ..convert import tojsonstr
 
 
 def query(CTERAHost, path, param):
-    response = CTERAHost.db(CTERAHost._api(), path, 'query', param)  # pylint: disable=protected-access
+    response = CTERAHost.db(path, 'query', param)
     return (response.hasMore, response.objects)
 
 
@@ -17,7 +17,7 @@ def show(CTERAHost, path, param):
 
 
 def iterator(CTERAHost, path, param):
-    function = Command(CTERAHost.query, path)
+    function = Command(query, CTERAHost, path)
     return Iterator(function, param)
 
 

--- a/cterasdk/core/servers.py
+++ b/cterasdk/core/servers.py
@@ -1,12 +1,14 @@
+from .base_command import BaseCommand
 from . import query
 from . import union
 
 
-default = ['name']
+class Servers(BaseCommand):
 
+    default = ['name']
 
-def servers(CTERAHost, include):
-    # browse administration
-    include = union.union(include, default)
-    param = query.QueryParamBuilder().include(include).build()
-    return CTERAHost.iterator('/servers', param)
+    def servers(self, include=None):
+        # browse administration
+        include = union.union(include or [], Servers.default)
+        param = query.QueryParamBuilder().include(include).build()
+        return query.iterator(self._portal, '/servers', param)

--- a/cterasdk/core/session.py
+++ b/cterasdk/core/session.py
@@ -5,7 +5,7 @@ from .enum import Context
 
 
 def inactive_session(Portal):
-    session = Session(Portal.host(), Portal._context())  # pylint: disable=protected-access
+    session = Session(Portal.host(), Portal.context)
     Portal.register_session(session)
 
 
@@ -88,5 +88,7 @@ class Session(Object):
         return self.status == SessionStatus.Initializing
 
     def authenticated(self):
-
         return self.status == SessionStatus.Active
+
+    def whoami(self):
+        print(self)

--- a/cterasdk/core/whoami.py
+++ b/cterasdk/core/whoami.py
@@ -1,3 +1,0 @@
-def whoami(CTERAHost):
-    session = CTERAHost.session()
-    print(session)

--- a/cterasdk/core/zones.py
+++ b/cterasdk/core/zones.py
@@ -2,189 +2,156 @@ import copy
 import logging
 import re
 
+from .base_command import BaseCommand
 from . import query
+from . import devices
+from . import cloudfs
 from ..common import Object
 from ..exception import CTERAException
 
 
-class Zones:
-
-    def __init__(self, Portal):
-        self._CTERAHost = Portal
+class Zones(BaseCommand):
 
     def get(self, name):
-        return get(self._CTERAHost, name)
+        query_filter = query.FilterBuilder('name').eq(name)
+        param = query.QueryParamBuilder().include_classname().startFrom(0).countLimit(1).addFilter(query_filter).orFilter(False).build()
+
+        logging.getLogger().info('Retrieving zone. %s', {'name': name})
+
+        response = self._portal.execute('', 'getZonesDisplayInfo', param)
+
+        objects = response.objects
+        if len(objects) < 1:
+            logging.getLogger().error('Zone not found. %s', {'name': name})
+            raise CTERAException('Zone not found', None, name=name)
+
+        zone = objects[0]
+        logging.getLogger().info('Zone found. %s', {'name': name, 'id': zone.zoneId})
+        return zone
 
     def add(self, name, policy_type='Select', description=None):
-        return add(self._CTERAHost, name, policy_type, description)
+        policy_type = {
+            'All': 'allFolders',
+            'Select': 'selectedFolders',
+            'None': 'noFolders'
+        }.get(policy_type)
+
+        param = self._zone_param(name, policy_type, description)
+
+        logging.getLogger().info('Adding zone. %s', {'name': name})
+
+        response = self._portal.execute('', 'addZone', param)
+        try:
+            self._process_response(response)
+        except CTERAException as error:
+            logging.getLogger().error('Zone creation failed. %s', {'rc': response.rc})
+            raise error
+        logging.getLogger().info('Zone added. %s', {'name': name})
 
     def delete(self, name):
-        return delete(self._CTERAHost, name)
+        zone = self.get(name)
+        logging.getLogger().info('Deleting zone. %s', {'zone': name})
+        response = self._portal.execute('', 'deleteZones', [zone.zoneId])
+        if response == 'ok':
+            logging.getLogger().info('Zone deleted. %s', {'zone': name})
 
-    def add_devices(self, name, devices):
-        return add_devices(self._CTERAHost, name, devices)
+    def add_devices(self, name, device_names):
+        zone = self.get(name)
+        portal_devices = devices.Devices(self._portal).by_name(include=['uid'], names=device_names)
+        info = self._zone_info(zone.zoneId)
+        description = (info.description if hasattr(info, 'description') else None)
+
+        param = self._zone_param(info.name, info.policyType, description, info.zoneId)
+        for portal_device in portal_devices:
+            param.delta.devicesDelta.added.append(portal_device.uid)
+
+        logging.getLogger().info('Adding devices to zone. %s', {'zone': info.name})
+
+        try:
+            self._save(param)
+        except CTERAException as error:
+            logging.getLogger().error('Failed adding devices to zone.')
+            raise error
 
     def add_folders(self, name, tuples):
-        return add_folders(self._CTERAHost, name, tuples)
+        zone = self.get(name)
+        folders = self._find_folders(tuples)
+        info = self._zone_info(zone.zoneId)
+        description = info.description if hasattr(info, 'description') else None
+        param = self._zone_param(info.name, info.policyType, description, info.zoneId)
+        param.delta.policyDelta = []
 
+        for owner_id, folder_ids in folders.items():
+            policyDelta = Object()
+            policyDelta._classname = 'ZonePolicyDelta'  # pylint: disable=protected-access
+            policyDelta.userUid = owner_id
+            policyDelta.foldersDelta = Object()
+            policyDelta.foldersDelta._classname = 'ZoneFolderDelta'  # pylint: disable=protected-access
+            policyDelta.foldersDelta.added = copy.deepcopy(folder_ids)
+            policyDelta.foldersDelta.removed = []
 
-def get(CTERAHost, name):
-    query_filter = query.FilterBuilder('name').eq(name)
-    param = query.QueryParamBuilder().include_classname().startFrom(0).countLimit(1).addFilter(query_filter).orFilter(False).build()
+            param.delta.policyDelta.append(policyDelta)
 
-    logging.getLogger().info('Retrieving zone. %s', {'name': name})
+        try:
+            self._save(param)
+        except CTERAException as error:
+            logging.getLogger().error('Failed adding folders to zone.')
+            raise error
 
-    response = CTERAHost.execute('', 'getZonesDisplayInfo', param)
+    def _zone_info(self, zid):
+        logging.getLogger().debug('Obtaining zone info. %s', {'id': zid})
+        response = self._portal.execute('', 'getZoneBasicInfo', zid)
+        logging.getLogger().debug('Obtained zone info. %s', {'id': zid})
+        return response
 
-    objects = response.objects
-    if len(objects) < 1:
-        logging.getLogger().error('Zone not found. %s', {'name': name})
-        raise CTERAException('Zone not found', None, name=name)
+    def _find_folders(self, tuples):
+        folders = {}
+        for name, owner in tuples:
+            cloud_folder = cloudfs.CloudFS(self._portal).find(name, owner, include=['uid', 'owner'])
+            folder_id = cloud_folder.uid
+            owner_id = re.search("[1-9][0-9]*", cloud_folder.owner).group(0)
 
-    zone = objects[0]
+            if folders.get(owner_id) is None:
+                folders[owner_id] = [folder_id]
+            else:
+                folders.get(owner_id).append(folder_id)
 
-    logging.getLogger().info('Zone found. %s', {'name': name, 'id': zone.zoneId})
+        return folders
 
-    return zone
+    def _save(self, param):
+        zone_name = param.basicInfo.name
 
+        logging.getLogger().debug('Applying changes to zone. %s', {'zone': param.basicInfo.name})
 
-def zone_info(CTERAHost, zid):
-    logging.getLogger().debug('Obtaining zone info. %s', {'id': zid})
+        response = self._portal.execute('', 'saveZone', param)
+        try:
+            self._process_response(response)
+        except CTERAException as error:
+            logging.getLogger().error('Failed applying changes to zone. %s', {'zone': zone_name, 'rc': response.rc})
+            raise error
 
-    response = CTERAHost.execute('', 'getZoneBasicInfo', zid)
+        logging.getLogger().debug('Zone changes applied successfully. %s', {'zone': zone_name})
 
-    logging.getLogger().debug('Obtained zone info. %s', {'id': zid})
+    @staticmethod
+    def _process_response(response):
+        if response.rc != 'OK':
+            raise CTERAException('Zone creation failed', response)
 
-    return response
+    @staticmethod
+    def _zone_param(name, policy_type, description=None, zid=None):
+        param = Object()
+        param._classname = "SaveZoneParam"  # pylint: disable=protected-access
+        param.basicInfo = Object()
+        param.basicInfo._classname = 'ZoneBasicInfo'  # pylint: disable=protected-access
+        param.basicInfo.name = name
+        param.basicInfo.policyType = policy_type
+        param.basicInfo.description = description
+        param.basicInfo.zoneId = zid
+        param.delta = Object()
+        param.delta._classname = 'ZoneDelta'  # pylint: disable=protected-access
+        param.delta.devicesDelta = Object()
+        param.delta.devicesDelta._classname = 'ZoneDeviceDelta'  # pylint: disable=protected-access
+        param.delta.devicesDelta.added = []
+        param.delta.devicesDelta.removed = []
 
-
-def add_devices(CTERAHost, zone_name, device_names):
-    zone = get(CTERAHost, zone_name)
-    devices = CTERAHost.devices_by_name(include=['uid'], names=device_names)
-    info = zone_info(CTERAHost, zone.zoneId)
-    description = (info.description if hasattr(info, 'description') else None)
-
-    param = zone_param(info.name, info.policyType, description, info.zoneId)
-    for device in devices:
-        param.delta.devicesDelta.added.append(device.uid)
-
-    logging.getLogger().info('Adding devices to zone. %s', {'zone': info.name})
-
-    try:
-        save(CTERAHost, param)
-    except CTERAException as error:
-        logging.getLogger().error('Failed adding devices to zone.')
-        raise error
-
-
-def add_folders(CTERAHost, zone_name, tuples):
-    zone = get(CTERAHost, zone_name)
-    folders = find_folders(CTERAHost, tuples)
-    info = zone_info(CTERAHost, zone.zoneId)
-    description = info.description if hasattr(info, 'description') else None
-    param = zone_param(info.name, info.policyType, description, info.zoneId)
-    param.delta.policyDelta = []
-
-    for owner_id, folder_ids in folders.items():
-        policyDelta = Object()
-        policyDelta._classname = 'ZonePolicyDelta'  # pylint: disable=protected-access
-        policyDelta.userUid = owner_id
-        policyDelta.foldersDelta = Object()
-        policyDelta.foldersDelta._classname = 'ZoneFolderDelta'  # pylint: disable=protected-access
-        policyDelta.foldersDelta.added = copy.deepcopy(folder_ids)
-        policyDelta.foldersDelta.removed = []
-
-        param.delta.policyDelta.append(policyDelta)
-
-    try:
-        save(CTERAHost, param)
-    except CTERAException as error:
-        logging.getLogger().error('Failed adding folders to zone.')
-        raise error
-
-
-def find_folders(CTERAHost, tuples):
-    cloudfs = CTERAHost.cloudfs()
-
-    folders = {}
-    for name, owner in tuples:
-        cloud_folder = cloudfs.find(name, owner, include=['uid', 'owner'])
-        folder_id = cloud_folder.uid
-        owner_id = re.search("[1-9][0-9]*", cloud_folder.owner).group(0)
-
-        if folders.get(owner_id) is None:
-            folders[owner_id] = [folder_id]
-        else:
-            folders.get(owner_id).append(folder_id)
-
-    return folders
-
-
-def save(CTERAHost, param):
-    zone_name = param.basicInfo.name
-
-    logging.getLogger().debug('Applying changes to zone. %s', {'zone': param.basicInfo.name})
-
-    response = CTERAHost.execute('', 'saveZone', param)
-    try:
-        process_response(response)
-    except CTERAException as error:
-        logging.getLogger().error('Failed applying changes to zone. %s', {'zone': zone_name, 'rc': response.rc})
-        raise error
-
-    logging.getLogger().debug('Zone changes applied successfully. %s', {'zone': zone_name})
-
-
-def add(CTERAHost, name, policy_type, description):
-    policy_type = {
-        'All': 'allFolders',
-        'Select': 'selectedFolders',
-        'None': 'noFolders'
-    }.get(policy_type)
-
-    param = zone_param(name, policy_type, description)
-
-    logging.getLogger().info('Adding zone. %s', {'name': name})
-
-    response = CTERAHost.execute('', 'addZone', param)
-    try:
-        process_response(response)
-    except CTERAException as error:
-        logging.getLogger().error('Zone creation failed. %s', {'rc': response.rc})
-        raise error
-
-    logging.getLogger().info('Zone added. %s', {'name': name})
-
-
-def process_response(response):
-    if response.rc != 'OK':
-        raise CTERAException('Zone creation failed', response)
-
-
-def zone_param(name, policy_type, description=None, zid=None):
-    param = Object()
-    param._classname = "SaveZoneParam"  # pylint: disable=protected-access
-    param.basicInfo = Object()
-    param.basicInfo._classname = 'ZoneBasicInfo'  # pylint: disable=protected-access
-    param.basicInfo.name = name
-    param.basicInfo.policyType = policy_type
-    param.basicInfo.description = description
-    param.basicInfo.zoneId = zid
-    param.delta = Object()
-    param.delta._classname = 'ZoneDelta'  # pylint: disable=protected-access
-    param.delta.devicesDelta = Object()
-    param.delta.devicesDelta._classname = 'ZoneDeviceDelta'  # pylint: disable=protected-access
-    param.delta.devicesDelta.added = []
-    param.delta.devicesDelta.removed = []
-
-    return param
-
-
-def delete(CTERAHost, name):
-    zone = get(CTERAHost, name)
-
-    logging.getLogger().info('Deleting zone. %s', {'zone': name})
-
-    response = CTERAHost.execute('', 'deleteZones', [zone.zoneId])
-    if response == 'ok':
-        logging.getLogger().info('Zone deleted. %s', {'zone': name})
+        return param

--- a/cterasdk/edge/__init__.py
+++ b/cterasdk/edge/__init__.py
@@ -19,7 +19,6 @@ __all__ = list(
             'groups',
             'licenses',
             'login',
-            'whoami',
             'logs',
             'mail',
             'network',

--- a/cterasdk/edge/afp.py
+++ b/cterasdk/edge/afp.py
@@ -1,11 +1,14 @@
 import logging
 
 from .enum import Mode
+from .base_command import BaseCommand
 
 
-def disable(ctera_host):
-    logging.getLogger().info('Disabling AFP server.')
+class AFP(BaseCommand):
 
-    ctera_host.put('/config/fileservices/afp/mode', Mode.Disabled)
+    def disable(self):
+        logging.getLogger().info('Disabling AFP server.')
 
-    logging.getLogger().info('AFP server disabled.')
+        self._gateway.put('/config/fileservices/afp/mode', Mode.Disabled)
+
+        logging.getLogger().info('AFP server disabled.')

--- a/cterasdk/edge/aio.py
+++ b/cterasdk/edge/aio.py
@@ -1,30 +1,27 @@
 import logging
+from .base_command import BaseCommand
 
 
-def enable(ctera_host):
-    logging.getLogger().info('Enabling asynchronous io.')
+class AIO(BaseCommand):
 
-    async_io(ctera_host, True, 1, 1)
+    def enable(self):
+        logging.getLogger().info('Enabling asynchronous io.')
+        self._async_io(True, 1, 1)
+        logging.getLogger().info('Asynchronous io enabled.')
 
-    logging.getLogger().info('Asynchronous io enabled.')
+    def disable(self):
+        logging.getLogger().info('Disabling asynchronous io.')
+        self._async_io(False, 0, 0)
+        logging.getLogger().info('Asynchronous io disabled.')
 
+    def _async_io(self, robustMutexes, aioReadThreshold, aioWriteThreshold):
+        logging.getLogger().debug('Obtaining CIFS server settings.')
 
-def disable(ctera_host):
-    logging.getLogger().info('Disabling asynchronous io.')
+        cifs = self._gateway.get('/config/fileservices/cifs')
+        cifs.robustMutexes = robustMutexes
+        cifs.aioReadThreshold = aioReadThreshold
+        cifs.aioWriteThreshold = aioWriteThreshold
 
-    async_io(ctera_host, False, 0, 0)
+        logging.getLogger().debug('Updating CIFS server settings.')
 
-    logging.getLogger().info('Asynchronous io disabled.')
-
-
-def async_io(ctera_host, robustMutexes, aioReadThreshold, aioWriteThreshold):
-    logging.getLogger().debug('Obtaining CIFS server settings.')
-
-    cifs = ctera_host.get('/config/fileservices/cifs')
-    cifs.robustMutexes = robustMutexes
-    cifs.aioReadThreshold = aioReadThreshold
-    cifs.aioWriteThreshold = aioWriteThreshold
-
-    logging.getLogger().debug('Updating CIFS server settings.')
-
-    ctera_host.put('/config/fileservices/cifs', cifs)
+        self._gateway.put('/config/fileservices/cifs', cifs)

--- a/cterasdk/edge/array.py
+++ b/cterasdk/edge/array.py
@@ -2,36 +2,37 @@ import logging
 
 from ..common import Object
 from ..exception import CTERAException
+from .base_command import BaseCommand
 
 
-def add(ctera_host, array_name, level, *args):
-    param = Object()
-    param.name = array_name
-    param.level = level
-    param.members = list(args)
+class Array(BaseCommand):
 
-    try:
-        logging.getLogger().info("Creating a storage array.")
-        response = ctera_host.add("/config/storage/arrays", param)
-        logging.getLogger().info("Storage array created.")
-        return response
-    except CTERAException as error:
-        logging.getLogger().error("Storage array creation failed.")
-        raise CTERAException("Storage array creation failed.", error)
+    def add(self, array_name, level, *args):
+        param = Object()
+        param.name = array_name
+        param.level = level
+        param.members = list(args)
 
+        try:
+            logging.getLogger().info("Creating a storage array.")
+            response = self._gateway.add("/config/storage/arrays", param)
+            logging.getLogger().info("Storage array created.")
+            return response
+        except CTERAException as error:
+            logging.getLogger().error("Storage array creation failed.")
+            raise CTERAException("Storage array creation failed.", error)
 
-def delete(ctera_host, array_name):
-    try:
-        logging.getLogger().info("Deleting a storage array.")
-        response = ctera_host.delete("/config/storage/arrays/" + array_name)
-        logging.getLogger().info("Storage array deleted. %s", {'array_name': array_name})
-        return response
-    except CTERAException as error:
-        logging.getLogger().error("Storage array deletion failed.")
-        raise CTERAException("Storage array deletion failed.", error)
+    def delete(self, array_name):
+        try:
+            logging.getLogger().info("Deleting a storage array.")
+            response = self._gateway.delete("/config/storage/arrays/" + array_name)
+            logging.getLogger().info("Storage array deleted. %s", {'array_name': array_name})
+            return response
+        except CTERAException as error:
+            logging.getLogger().error("Storage array deletion failed.")
+            raise CTERAException("Storage array deletion failed.", error)
 
-
-def delete_all(ctera_host):
-    arrays = ctera_host.get('/config/storage/arrays')
-    for array in arrays:
-        delete(ctera_host, array.name)
+    def delete_all(self):
+        arrays = self._gateway.get('/config/storage/arrays')
+        for array in arrays:
+            self.delete(array.name)

--- a/cterasdk/edge/audit.py
+++ b/cterasdk/edge/audit.py
@@ -1,20 +1,41 @@
-from .enum import Mode
+from . import enum
 from ..common import Object
+from .base_command import BaseCommand
 
 
-def enable(ctera_host, path, auditEvents, logKeepPeriod, maxLogKBSize, maxRotateTime, includeAuditLogTag, humanReadableAuditLog):
-    settings = Object()
-    settings.mode = Mode.Enabled
-    settings.path = path
-    settings.auditEvents = auditEvents
-    settings.logKeepPeriod = logKeepPeriod
-    settings.maxLogKBSize = maxLogKBSize
-    settings.maxRotateTime = maxRotateTime
-    settings.includeAuditLogTag = includeAuditLogTag
-    settings.humanReadableAuditLog = humanReadableAuditLog
+class Audit(BaseCommand):
 
-    ctera_host.put('/config/logging/files', settings)
+    defaultAuditEvents = [
+        enum.AuditEvents.CreateFilesWriteData,
+        enum.AuditEvents.CreateFoldersAppendData,
+        enum.AuditEvents.WriteExtendedAttributes,
+        enum.AuditEvents.DeleteSubfoldersAndFiles,
+        enum.AuditEvents.WriteAttributes,
+        enum.AuditEvents.Delete,
+        enum.AuditEvents.ChangePermissions,
+        enum.AuditEvents.ChangeOwner
+    ]
 
+    def enable(
+            self,
+            path,
+            auditEvents=None,
+            logKeepPeriod=30,
+            maxLogKBSize=102400,
+            maxRotateTime=1440,
+            includeAuditLogTag=True,
+            humanReadableAuditLog=False):
+        settings = Object()
+        settings.mode = enum.Mode.Enabled
+        settings.path = path
+        settings.auditEvents = auditEvents or Audit.defaultAuditEvents
+        settings.logKeepPeriod = logKeepPeriod
+        settings.maxLogKBSize = maxLogKBSize
+        settings.maxRotateTime = maxRotateTime
+        settings.includeAuditLogTag = includeAuditLogTag
+        settings.humanReadableAuditLog = humanReadableAuditLog
 
-def disable(ctera_host):
-    ctera_host.put('/config/logging/files/mode', Mode.Disabled)
+        self._gateway.put('/config/logging/files', settings)
+
+    def disable(self):
+        self._gateway.put('/config/logging/files/mode', enum.Mode.Disabled)

--- a/cterasdk/edge/base_command.py
+++ b/cterasdk/edge/base_command.py
@@ -1,0 +1,7 @@
+class BaseCommand:
+
+    def __init__(self, gateway):
+        self._gateway = gateway
+
+    def session(self):
+        return self._gateway.session()

--- a/cterasdk/edge/cache.py
+++ b/cterasdk/edge/cache.py
@@ -1,24 +1,24 @@
 import logging
 
 from .enum import OperationMode
+from .base_command import BaseCommand
 
 
-def enable(ctera_host):
-    logging.getLogger().info('Enabling caching.')
-    _set_operation_mode(ctera_host, OperationMode.CachingGateway)
+class Cache(BaseCommand):
 
+    def enable(self):
+        logging.getLogger().info('Enabling caching.')
+        self._set_operation_mode(OperationMode.CachingGateway)
 
-def disable(ctera_host):
-    logging.getLogger().info('Disabling caching.')
-    _set_operation_mode(ctera_host, OperationMode.Disabled)
+    def disable(self):
+        logging.getLogger().info('Disabling caching.')
+        self._set_operation_mode(OperationMode.Disabled)
 
+    def force_eviction(self):
+        logging.getLogger().info("Starting file eviction.")
+        self._gateway.execute("/config/cloudsync", "forceExecuteEvictor", None)
+        logging.getLogger().info("Eviction started.")
 
-def _set_operation_mode(ctera_host, mode):
-    ctera_host.put('/config/cloudsync/cloudExtender/operationMode', mode)
-    logging.getLogger().info('Device opreation mode changed. %s', {'mode': mode})
-
-
-def force_eviction(ctera_host):
-    logging.getLogger().info("Starting file eviction.")
-    ctera_host.execute("/config/cloudsync", "forceExecuteEvictor", None)
-    logging.getLogger().info("Eviction started.")
+    def _set_operation_mode(self, mode):
+        self._gateway.put('/config/cloudsync/cloudExtender/operationMode', mode)
+        logging.getLogger().info('Device opreation mode changed. %s', {'mode': mode})

--- a/cterasdk/edge/cli.py
+++ b/cterasdk/edge/cli.py
@@ -1,11 +1,15 @@
 import logging
 
+from .base_command import BaseCommand
 
-def run_cli_command(ctera_host, cli_command):
-    logging.getLogger().info("Executing CLI command. %s", {'cli_command': cli_command})
 
-    response = ctera_host.execute('/config/device', 'debugCmd', cli_command)
+class CLI(BaseCommand):
 
-    logging.getLogger().info("CLI command executed. %s", {'cli_command': cli_command})
+    def run_command(self, cli_command):
+        logging.getLogger().info("Executing CLI command. %s", {'cli_command': cli_command})
 
-    return response
+        response = self._gateway.execute('/config/device', 'debugCmd', cli_command)
+
+        logging.getLogger().info("CLI command executed. %s", {'cli_command': cli_command})
+
+        return response

--- a/cterasdk/edge/config.py
+++ b/cterasdk/edge/config.py
@@ -1,19 +1,20 @@
 import logging
 
-
-def get_location(ctera_host):
-    return ctera_host.get('/config/device/location')
+from .base_command import BaseCommand
 
 
-def set_location(ctera_host, location):
-    logging.getLogger().info('Configuring device location. %s', {'location': location})
-    return ctera_host.put('/config/device/location', location)
+class Config(BaseCommand):
 
+    def get_location(self):
+        return self._gateway.get('/config/device/location')
 
-def get_hostname(ctera_host):
-    return ctera_host.get('/config/device/hostname')
+    def set_location(self, location):
+        logging.getLogger().info('Configuring device location. %s', {'location': location})
+        return self._gateway.put('/config/device/location', location)
 
+    def get_hostname(self):
+        return self._gateway.get('/config/device/hostname')
 
-def set_hostname(ctera_host, hostname):
-    logging.getLogger().info('Configuring device hostname. %s', {'hostname': hostname})
-    return ctera_host.put('/config/device/hostname', hostname)
+    def set_hostname(self, hostname):
+        logging.getLogger().info('Configuring device hostname. %s', {'hostname': hostname})
+        return self._gateway.put('/config/device/hostname', hostname)

--- a/cterasdk/edge/drive.py
+++ b/cterasdk/edge/drive.py
@@ -1,29 +1,31 @@
 import logging
 
 from ..common import Object
+from .base_command import BaseCommand
 
 
-def format_drive(ctera_host, name):
-    '''
-    {
-        "desc": "Format a drive"
-    }
-    '''
-    param = Object()
-    param.name = name
+class Drive(BaseCommand):
 
-    ctera_host.execute("/proc/storage", "format", param)
+    def format(self, name):
+        '''
+        {
+            "desc": "Format a drive"
+        }
+        '''
+        param = Object()
+        param.name = name
 
-    logging.getLogger().info('Formatting drive. %s', {'drive': name})
+        self._gateway.execute("/proc/storage", "format", param)
 
+        logging.getLogger().info('Formatting drive. %s', {'drive': name})
 
-def format_all(ctera_host):
-    '''
-    {
-        "desc": "Format all drives"
-    }
-    '''
-    drives = ctera_host.get('/status/storage/disks')
+    def format_all(self):
+        '''
+        {
+            "desc": "Format all drives"
+        }
+        '''
+        drives = self._gateway.get('/status/storage/disks')
 
-    for drive in drives:
-        format_drive(ctera_host, drive.name)
+        for drive in drives:
+            self.format(drive.name)

--- a/cterasdk/edge/files/browser.py
+++ b/cterasdk/edge/files/browser.py
@@ -23,6 +23,3 @@ class FileBrowser:
     @staticmethod
     def mkpath(path):
         return CTERAPath(path, '/')
-
-    def _files(self):
-        return self._CTERAHost._files()  # pylint: disable=protected-access

--- a/cterasdk/edge/files/mkdir.py
+++ b/cterasdk/edge/files/mkdir.py
@@ -35,7 +35,7 @@ def _mkdir(ctera_host, path):
     fullpath = path.fullpath()
     logging.getLogger().info('Creating directory. %s', {'path': fullpath})
     try:
-        ctera_host.mkcol(ctera_host._files(), fullpath)  # pylint: disable=protected-access
+        ctera_host.mkcol(fullpath, use_file_url=True)
     except CTERAException as error:
         _process_error(error, fullpath)
     logging.getLogger().info('Directory created. %s', {'path': fullpath})

--- a/cterasdk/edge/files/open.py
+++ b/cterasdk/edge/files/open.py
@@ -4,4 +4,4 @@ import logging
 def openfile(ctera_host, path):
     fullpath = path.fullpath()
     logging.getLogger().info('Obtaining file handle. %s', {'path': fullpath})
-    return ctera_host.openfile(ctera_host._files(), fullpath, params={})  # pylint: disable=protected-access
+    return ctera_host.openfile(fullpath, use_file_url=True)

--- a/cterasdk/edge/ftp.py
+++ b/cterasdk/edge/ftp.py
@@ -1,11 +1,14 @@
 import logging
 
 from .enum import Mode
+from .base_command import BaseCommand
 
 
-def disable(ctera_host):
-    logging.getLogger().info('Disabling FTP server.')
+class FTP(BaseCommand):
 
-    ctera_host.put('/config/fileservices/ftp/mode', Mode.Disabled)
+    def disable(self):
+        logging.getLogger().info('Disabling FTP server.')
 
-    logging.getLogger().info('FTP server disabled.')
+        self._gateway.put('/config/fileservices/ftp/mode', Mode.Disabled)
+
+        logging.getLogger().info('FTP server disabled.')

--- a/cterasdk/edge/groups.py
+++ b/cterasdk/edge/groups.py
@@ -3,86 +3,87 @@ import logging
 from ..common import Object
 from ..exception import InputError
 from .enum import PrincipalType
+from .base_command import BaseCommand
 
 
-def add_members(ctera_host, group, new_members):
-    current_members = ctera_host.get('/config/auth/groups/' + group + '/members')
+class Groups(BaseCommand):
 
-    new_member_dict = {}
-    for new_member in new_members:
-        if len(new_member) != 2:
-            raise InputError('Invalid input', repr(new_member), '[("type", "name"), ...]')
+    def add_members(self, group, new_members):
+        current_members = self._gateway.get('/config/auth/groups/' + group + '/members')
 
-        new_member_type, new_member_name = new_member
-        new_member_type, new_member = _member(new_member_type, new_member_name)
-        new_member_dict[new_member_type + '#' + new_member_name] = new_member
+        new_member_dict = {}
+        for new_member in new_members:
+            if len(new_member) != 2:
+                raise InputError('Invalid input', repr(new_member), '[("type", "name"), ...]')
+            new_member_type, new_member_name = new_member
+            new_member_type, new_member = Groups._member(new_member_type, new_member_name)
+            new_member_dict[new_member_type + '#' + new_member_name] = new_member
 
-    for current_member in current_members:
-        current_member_type = current_member._classname  # pylint: disable=protected-access
+        for current_member in current_members:
+            current_member_type = current_member._classname  # pylint: disable=protected-access
 
-        if current_member_type in [PrincipalType.LU, PrincipalType.LG]:
-            current_member_name = current_member.ref
-            current_member_name = current_member_name[current_member_name.rfind('#') + 1:]
+            if current_member_type in [PrincipalType.LU, PrincipalType.LG]:
+                current_member_name = current_member.ref
+                current_member_name = current_member_name[current_member_name.rfind('#') + 1:]
+            else:
+                current_member_name = current_member.name
+
+            current_member_key = current_member_type + '#' + current_member_name
+
+            if current_member_key not in new_member_dict:
+                new_member_dict[current_member_key] = current_member
+
+        members = [v for k, v in new_member_dict.items()]
+
+        logging.getLogger().info('Adding group members. %s', {'group': group})
+
+        self._gateway.put('/config/auth/groups/' + group + '/members', members)
+
+        logging.getLogger().info('Group members added. %s', {'group': group})
+
+    def remove_members(self, group, tuples):
+        current_members = self._gateway.get('/config/auth/groups/' + group + '/members')
+        options = {v: k for k, v in PrincipalType.__dict__.items() if not k.startswith('_')}  # reverse
+
+        members = []
+        for current_member in current_members:
+            current_member_type = current_member._classname  # pylint: disable=protected-access
+
+            if current_member_type in [PrincipalType.LU, PrincipalType.LG]:
+                current_member_name = current_member.ref
+                current_member_name = current_member_name[current_member_name.rfind('#') + 1:]
+            else:
+                current_member_name = current_member.name
+
+            if not (options.get(current_member_type), current_member_name) in tuples:
+                members.append(current_member)
+
+        logging.getLogger().info('Removing group members. %s', {'group': group})
+
+        self._gateway.put('/config/auth/groups/' + group + '/members', members)
+
+        logging.getLogger().info('Group members removed. %s', {'group': group})
+
+    @staticmethod
+    def _member(member_type, name):
+        options = {k: v for k, v in PrincipalType.__dict__.items() if not k.startswith('_')}
+
+        member = Object()
+        member_type = options.get(member_type)
+
+        if member_type == PrincipalType.LU:
+            member._classname = PrincipalType.LU  # pylint: disable=protected-access
+            member.ref = "#config#auth#users#" + name
+        elif member_type == PrincipalType.LG:
+            member._classname = PrincipalType.LG  # pylint: disable=protected-access
+            member.ref = "#config#auth#groups#" + name
+        elif member_type == PrincipalType.DU:
+            member._classname = PrincipalType.DU  # pylint: disable=protected-access
+            member.name = name
+        elif member_type == PrincipalType.DG:
+            member._classname = PrincipalType.DG  # pylint: disable=protected-access
+            member.name = name
         else:
-            current_member_name = current_member.name
+            raise InputError('Invalid principal type', member_type, list(options.keys()))
 
-        current_member_key = current_member_type + '#' + current_member_name
-
-        if current_member_key not in new_member_dict:
-            new_member_dict[current_member_key] = current_member
-
-    members = [v for k, v in new_member_dict.items()]
-
-    logging.getLogger().info('Adding group members. %s', {'group': group})
-
-    ctera_host.put('/config/auth/groups/' + group + '/members', members)
-
-    logging.getLogger().info('Group members added. %s', {'group': group})
-
-
-def remove_members(ctera_host, group, tuples):
-    current_members = ctera_host.get('/config/auth/groups/' + group + '/members')
-    options = {v: k for k, v in PrincipalType.__dict__.items() if not k.startswith('_')}  # reverse
-
-    members = []
-    for current_member in current_members:
-        current_member_type = current_member._classname  # pylint: disable=protected-access
-
-        if current_member_type in [PrincipalType.LU, PrincipalType.LG]:
-            current_member_name = current_member.ref
-            current_member_name = current_member_name[current_member_name.rfind('#') + 1:]
-        else:
-            current_member_name = current_member.name
-
-        if not (options.get(current_member_type), current_member_name) in tuples:
-            members.append(current_member)
-
-    logging.getLogger().info('Removing group members. %s', {'group': group})
-
-    ctera_host.put('/config/auth/groups/' + group + '/members', members)
-
-    logging.getLogger().info('Group members removed. %s', {'group': group})
-
-
-def _member(member_type, name):
-    options = {k: v for k, v in PrincipalType.__dict__.items() if not k.startswith('_')}
-
-    member = Object()
-    member_type = options.get(member_type)
-
-    if member_type == PrincipalType.LU:
-        member._classname = PrincipalType.LU  # pylint: disable=protected-access
-        member.ref = "#config#auth#users#" + name
-    elif member_type == PrincipalType.LG:
-        member._classname = PrincipalType.LG  # pylint: disable=protected-access
-        member.ref = "#config#auth#groups#" + name
-    elif member_type == PrincipalType.DU:
-        member._classname = PrincipalType.DU  # pylint: disable=protected-access
-        member.name = name
-    elif member_type == PrincipalType.DG:
-        member._classname = PrincipalType.DG  # pylint: disable=protected-access
-        member.name = name
-    else:
-        raise InputError('Invalid principal type', member_type, list(options.keys()))
-
-    return member_type, member
+        return member_type, member

--- a/cterasdk/edge/licenses.py
+++ b/cterasdk/edge/licenses.py
@@ -2,23 +2,26 @@ import logging
 
 from ..exception import InputError
 from .enum import License
+from .base_command import BaseCommand
 
 
-def infer(ctera_license):
-    if License.__dict__.get(ctera_license) is None:
-        logging.getLogger().error('Invalid license type. %s', {'license': ctera_license})
-        options = [v for k, v in License.__dict__.items() if not k.startswith('_')]
-        raise InputError('Invalid license type', ctera_license, options)
+class Licenses(BaseCommand):
 
-    ctera_license = License.__dict__.get(ctera_license)
-    return 'vGateway' + ('' if ctera_license == 'EV16' else ctera_license[2:])
+    @staticmethod
+    def infer(ctera_license):
+        if License.__dict__.get(ctera_license) is None:
+            logging.getLogger().error('Invalid license type. %s', {'license': ctera_license})
+            options = [v for k, v in License.__dict__.items() if not k.startswith('_')]
+            raise InputError('Invalid license type', ctera_license, options)
 
+        ctera_license = License.__dict__.get(ctera_license)
+        return 'vGateway' + ('' if ctera_license == 'EV16' else ctera_license[2:])
 
-def apply(ctera_host, ctera_license):
-    inferred_license = infer(ctera_license)
+    def apply(self, ctera_license):
+        inferred_license = Licenses.infer(ctera_license)
 
-    logging.getLogger().info('Applying license. %s', {'license': ctera_license})
+        logging.getLogger().info('Applying license. %s', {'license': ctera_license})
 
-    ctera_host.put('/config/device/activeLicenseType', inferred_license)
+        self._gateway.put('/config/device/activeLicenseType', inferred_license)
 
-    logging.getLogger().info('License applied. %s', {'license': ctera_license})
+        logging.getLogger().info('License applied. %s', {'license': ctera_license})

--- a/cterasdk/edge/login.py
+++ b/cterasdk/edge/login.py
@@ -2,23 +2,25 @@ import logging
 
 from . import session
 from ..exception import CTERAException
+from .base_command import BaseCommand
 
 
-def login(ctera_host, username, password):
-    host = ctera_host.host()
-    try:
-        ctera_host.form_data('/login', {'username': username, 'password': password})
-        logging.getLogger().info("User logged in. %s", {'host': host, 'user': username})
-        session.start_local_session(ctera_host, host, username)
-    except CTERAException as error:
-        logging.getLogger().error("Login failed. %s", {'host': host, 'user': username})
-        raise error
+class Login(BaseCommand):
 
+    def login(self, username, password):
+        host = self._gateway.host()
+        try:
+            self._gateway.form_data('/login', {'username': username, 'password': password})
+            logging.getLogger().info("User logged in. %s", {'host': host, 'user': username})
+            session.start_local_session(self._gateway, host, username)
+        except CTERAException as error:
+            logging.getLogger().error("Login failed. %s", {'host': host, 'user': username})
+            raise error
 
-def logout(ctera_host):
-    try:
-        ctera_host.form_data('/logout', {'foo': 'bar'})
-        session.terminate(ctera_host)
-        logging.getLogger().info("User logged out. %s", {'host': ctera_host.host()})
-    except CTERAException as error:
-        raise error
+    def logout(self):
+        try:
+            self._gateway.form_data('/logout', {'foo': 'bar'})
+            session.terminate(self._gateway)
+            logging.getLogger().info("User logged out. %s", {'host': self._gateway.host()})
+        except CTERAException as error:
+            raise error

--- a/cterasdk/edge/logs.py
+++ b/cterasdk/edge/logs.py
@@ -1,13 +1,18 @@
 from ..lib import Command, Iterator
 from . import query
+from . import enum
+from .base_command import BaseCommand
 
 
-def query_logs(ctera_host, param):
-    response = ctera_host.execute('/config/logging/general', 'pagedQuery', param)
-    return (response.hasMore, response.logs)
+class Logs(BaseCommand):
+    default_include = ['severity', 'time', 'msg', 'more']
 
+    def logs(self, topic, include=None, minSeverity=enum.Severity.INFO):
+        param = query.QueryParamBuilder().include(
+            include or Logs.default_include).put('topic', topic).put('minSeverity', minSeverity).build()
+        function = Command(self._query_logs)
+        return Iterator(function, param)
 
-def logs(ctera_host, topic, include, minSeverity):
-    param = query.QueryParamBuilder().include(include).put('topic', topic).put('minSeverity', minSeverity).build()
-    function = Command(query_logs, ctera_host)
-    return Iterator(function, param)
+    def _query_logs(self, param):
+        response = self._gateway.execute('/config/logging/general', 'pagedQuery', param)
+        return (response.hasMore, response.logs)

--- a/cterasdk/edge/mail.py
+++ b/cterasdk/edge/mail.py
@@ -1,36 +1,38 @@
 import logging
 
 from ..common import Object
+from .base_command import BaseCommand
 
 
-def enable(ctera_host, SMTPServer, port, username, password, useTLS):
-    settings = ctera_host.get('/config/logging/alert')
-    settings.useCustomServer = True
-    settings.SMTPServer = SMTPServer
+class Mail(BaseCommand):
 
-    if settings.port != port:
-        settings.port = port
+    def enable(self, SMTPServer, port=25, username=None, password=None, useTLS=True):
+        settings = self._gateway.get('/config/logging/alert')
+        settings.useCustomServer = True
+        settings.SMTPServer = SMTPServer
 
-    if username is not None and password is not None:
-        settings.useAuth = True
-        settings.auth = Object()
-        settings.auth.username = username
-        settings.auth.password = password
+        if settings.port != port:
+            settings.port = port
 
-    if settings.useTLS != useTLS:
-        settings.useTLS = useTLS
+        if username is not None and password is not None:
+            settings.useAuth = True
+            settings.auth = Object()
+            settings.auth.username = username
+            settings.auth.password = password
 
-    logging.getLogger().info('Enabling mail server.')
+        if settings.useTLS != useTLS:
+            settings.useTLS = useTLS
 
-    ctera_host.put('/config/logging/alert', settings)
+        logging.getLogger().info('Enabling mail server.')
 
-    logging.getLogger().info(
-        'Updated mail server settings. %s',
-        {'SMTPServer': SMTPServer, 'port': port, 'username': username, 'useTLS': useTLS}
-    )
+        self._gateway.put('/config/logging/alert', settings)
 
+        logging.getLogger().info(
+            'Updated mail server settings. %s',
+            {'SMTPServer': SMTPServer, 'port': port, 'username': username, 'useTLS': useTLS}
+        )
 
-def disable(ctera_host):
-    logging.getLogger().info('Disabling mail server.')
-    ctera_host.put('/config/logging/alert/useCustomServer', False)
-    logging.getLogger().info('Mail server disabled.')
+    def disable(self):
+        logging.getLogger().info('Disabling mail server.')
+        self._gateway.put('/config/logging/alert/useCustomServer', False)
+        logging.getLogger().info('Mail server disabled.')

--- a/cterasdk/edge/network.py
+++ b/cterasdk/edge/network.py
@@ -3,73 +3,73 @@ import logging
 from .enum import Mode
 from . import taskmgr as TaskManager
 from ..common import Object
+from .base_command import BaseCommand
 
 
-def set_static_ipaddr(ctera_host, address, subnet, gateway, DNSServer1, DNSServer2):
-    ip = ctera_host.get('/config/network/ports/0/ip')
-    ip.DHCPMode = Mode.Disabled
-    ip.address = address
-    ip.netmask = subnet
-    ip.gateway = gateway
-    ip.autoObtainDNS = False
-    ip.DNSServer1 = DNSServer1
+class Network(BaseCommand):
 
-    if DNSServer2 is not None:
-        ip.DNSServer2 = DNSServer2
+    def set_static_ipaddr(self, address, subnet, gateway, DNSServer1, DNSServer2=None):
+        ip = self._gateway.get('/config/network/ports/0/ip')
+        ip.DHCPMode = Mode.Disabled
+        ip.address = address
+        ip.netmask = subnet
+        ip.gateway = gateway
+        ip.autoObtainDNS = False
+        ip.DNSServer1 = DNSServer1
 
-    logging.getLogger().info('Configuring a static ip address.')
+        if DNSServer2 is not None:
+            ip.DNSServer2 = DNSServer2
 
-    ctera_host.put('/config/network/ports/0/ip', ip)
+        logging.getLogger().info('Configuring a static ip address.')
 
-    logging.getLogger().info(
-        'Network settings updated. %s',
-        {'address': address, 'subnet': subnet, 'gateway': gateway, 'DNS1': DNSServer1, 'DNS2': DNSServer2}
-    )
+        self._gateway.put('/config/network/ports/0/ip', ip)
 
+        logging.getLogger().info(
+            'Network settings updated. %s',
+            {'address': address, 'subnet': subnet, 'gateway': gateway, 'DNS1': DNSServer1, 'DNS2': DNSServer2}
+        )
 
-def set_static_nameserver(ctera_host, DNSServer1, DNSServer2):
-    ip = ctera_host.get('/config/network/ports/0/ip')
-    ip.autoObtainDNS = False
-    ip.DNSServer1 = DNSServer1
+    def set_static_nameserver(self, DNSServer1, DNSServer2=None):
+        ip = self._gateway.get('/config/network/ports/0/ip')
+        ip.autoObtainDNS = False
+        ip.DNSServer1 = DNSServer1
 
-    if DNSServer2 is not None:
-        ip.DNSServer2 = DNSServer2
+        if DNSServer2 is not None:
+            ip.DNSServer2 = DNSServer2
 
-    logging.getLogger().info('Configuring nameserver settings.')
+        logging.getLogger().info('Configuring nameserver settings.')
 
-    ctera_host.put('/config/network/ports/0/ip', ip)
+        self._gateway.put('/config/network/ports/0/ip', ip)
 
-    logging.getLogger().info('Nameserver settings updated. %s', {'DNS1': DNSServer1, 'DNS2': DNSServer2})
+        logging.getLogger().info('Nameserver settings updated. %s', {'DNS1': DNSServer1, 'DNS2': DNSServer2})
 
+    def enable_dhcp(self):
+        ip = self._gateway.get('/config/network/ports/0/ip')
+        ip.DHCPMode = Mode.Enabled
+        ip.autoObtainDNS = True
 
-def enable_dhcp(ctera_host):
-    ip = ctera_host.get('/config/network/ports/0/ip')
-    ip.DHCPMode = Mode.Enabled
-    ip.autoObtainDNS = True
+        logging.getLogger().info('Enabling DHCP.')
 
-    logging.getLogger().info('Enabling DHCP.')
+        self._gateway.put('/config/network/ports/0/ip', ip)
 
-    ctera_host.put('/config/network/ports/0/ip', ip)
+        logging.getLogger().info('Network settings updated. Enabled DHCP.')
 
-    logging.getLogger().info('Network settings updated. Enabled DHCP.')
+    def tcp_connect(self, address, port):
+        param = Object()
+        param.address = address
+        param.port = port
 
+        logging.getLogger().info("Testing connection. %s", {'address': address, 'port': port})
 
-def tcp_connect(ctera_host, address, port):
-    param = Object()
-    param.address = address
-    param.port = port
+        task = self._gateway.execute("/status/network", "tcpconnect", param)
+        try:
+            task = TaskManager.wait(self._gateway, task)
+            logging.getLogger().debug("Obtained connection status. %s", {'status': task.result.rc})
+            if task.result.rc == "Open":
+                return True
+        except TaskManager.TaskError:
+            pass
 
-    logging.getLogger().info("Testing connection. %s", {'address': address, 'port': port})
+        logging.getLogger().warning("Couldn't establish TCP connection. %s", {'address': address, 'port': port})
 
-    task = ctera_host.execute("/status/network", "tcpconnect", param)
-    try:
-        task = TaskManager.wait(ctera_host, task)
-        logging.getLogger().debug("Obtained connection status. %s", {'status': task.result.rc})
-        if task.result.rc == "Open":
-            return True
-    except TaskManager.TaskError:
-        pass
-
-    logging.getLogger().warning("Couldn't establish TCP connection. %s", {'address': address, 'port': port})
-
-    return False
+        return False

--- a/cterasdk/edge/nfs.py
+++ b/cterasdk/edge/nfs.py
@@ -1,12 +1,15 @@
 import logging
 
 from .enum import Mode
+from .base_command import BaseCommand
 
 
-def disable(ctera_host):
+class NFS(BaseCommand):
 
-    logging.getLogger().info('Disabling NFS server.')
+    def disable(self):
 
-    ctera_host.put('/config/fileservices/nfs/mode', Mode.Disabled)
+        logging.getLogger().info('Disabling NFS server.')
 
-    logging.getLogger().info('NFS server disabled.')
+        self._gateway.put('/config/fileservices/nfs/mode', Mode.Disabled)
+
+        logging.getLogger().info('NFS server disabled.')

--- a/cterasdk/edge/ntp.py
+++ b/cterasdk/edge/ntp.py
@@ -1,26 +1,28 @@
 import logging
 
 from .enum import Mode
+from .base_command import BaseCommand
 
 
-def enable(ctera_host, servers):
-    logging.getLogger().info("Enabling time synchronization with ntp servers.")
+class NTP(BaseCommand):
 
-    ctera_host.put('/config/time/NTPMode', Mode.Enabled)
+    def enable(self, servers=None):
+        logging.getLogger().info("Enabling time synchronization with ntp servers.")
 
-    logging.getLogger().info("Time synchronization enabled.")
+        self._gateway.put('/config/time/NTPMode', Mode.Enabled)
 
-    if len(servers) > 0:
-        logging.getLogger().info("Updating time servers. %s", {'servers': servers})
+        logging.getLogger().info("Time synchronization enabled.")
 
-        ctera_host.put('/config/time/NTPServer', servers)
+        if servers:
+            logging.getLogger().info("Updating time servers. %s", {'servers': servers})
 
-        logging.getLogger().info("Time servers updated. %s", {'servers': servers})
+            self._gateway.put('/config/time/NTPServer', servers)
 
+            logging.getLogger().info("Time servers updated. %s", {'servers': servers})
 
-def disable(ctera_host):
-    logging.getLogger().info("Disabling time synchronization with ntp servers.")
+    def disable(self):
+        logging.getLogger().info("Disabling time synchronization with ntp servers.")
 
-    ctera_host.put('/config/time/NTPMode', Mode.Disabled)
+        self._gateway.put('/config/time/NTPMode', Mode.Disabled)
 
-    logging.getLogger().info("Time synchronization disabled.")
+        logging.getLogger().info("Time synchronization disabled.")

--- a/cterasdk/edge/query.py
+++ b/cterasdk/edge/query.py
@@ -6,7 +6,7 @@ def query(CTERAHost, path, key, value):
     param = Object()
     param.key = key
     param.value = value
-    return CTERAHost.db(CTERAHost._api(), path, 'query', param)  # pylint: disable=protected-access
+    return CTERAHost.db(path, 'query', param)
 
 
 def show(CTERAHost, path, key, value):

--- a/cterasdk/edge/rsync.py
+++ b/cterasdk/edge/rsync.py
@@ -1,9 +1,12 @@
 import logging
 
 from .enum import Mode
+from .base_command import BaseCommand
 
 
-def disable(ctera_host):
-    logging.getLogger().info('Disabling RSync server.')
-    ctera_host.put('/config/fileservices/rsync/server', Mode.Disabled)
-    logging.getLogger().info('RSync server disabled.')
+class RSync(BaseCommand):
+
+    def disable(self):
+        logging.getLogger().info('Disabling RSync server.')
+        self._gateway.put('/config/fileservices/rsync/server', Mode.Disabled)
+        logging.getLogger().info('RSync server disabled.')

--- a/cterasdk/edge/services.py
+++ b/cterasdk/edge/services.py
@@ -1,118 +1,112 @@
 import logging
 
-from .licenses import infer
-from .network import tcp_connect
+from .licenses import Licenses
 from . import taskmgr as TaskManager
 from ..lib import ask
 from ..common import Object
 from ..exception import CTERAException, InputError, CTERAConnectionError
 from .. import config
+from . import enum
+from .base_command import BaseCommand
 
 
-def connect(ctera_host, server, user, password, ctera_license):
-    validate_license(ctera_license)
-    check_cttp_traffic(ctera_host, address=server)
-    check_connection(ctera_host, server)
+class Services(BaseCommand):
 
-    param = Object()
-    param.server = server
-    param.user = user
-    param.password = password
-    connect_to_services(ctera_host, param, ctera_license)
+    def connect(self, server, user, password, ctera_license=enum.License.EV16):
+        Services._validate_license(ctera_license)
+        self._check_cttp_traffic(address=server)
+        self._check_connection(server)
 
+        param = Object()
+        param.server = server
+        param.user = user
+        param.password = password
+        self._connect_to_services(param, ctera_license)
 
-def activate(ctera_host, server, user, code, ctera_license):
-    validate_license(ctera_license)
-    check_cttp_traffic(ctera_host, address=server)
+    def activate(self, server, user, code, ctera_license=enum.License.EV16):
+        Services._validate_license(ctera_license)
+        self._check_cttp_traffic(address=server)
 
-    param = Object()
-    param.server = server
-    param.user = user
-    param.activationCode = code
-    connect_to_services(ctera_host, param, ctera_license)
+        param = Object()
+        param.server = server
+        param.user = user
+        param.activationCode = code
+        self._connect_to_services(param, ctera_license)
 
+    def reconnect(self):
+        self._gateway.execute("/status/services", "reconnect", None)
 
-def connect_to_services(ctera_host, param, ctera_license):
-    task = attach(ctera_host, param)
-    try:
-        TaskManager.wait(ctera_host, task)
-        logging.getLogger().info("Connected to Portal.")
-    except TaskManager.TaskError as error:
-        description = error.task.description
-        logging.getLogger().error("Connection failed. Reason: %s", description)
-        raise CTERAException("Connection failed", None, reason=description)
-    ctera_host.apply_license(ctera_license)
+    def disconnect(self):
+        self._gateway.put('/config/services', None)
 
+    def enable_sso(self):
+        logging.getLogger().info('Enabling single sign-on from CTERA Portal.')
+        self._gateway.put('/config/gui/adminRemoteAccessSSO', True)
+        logging.getLogger().info('Single sign-on enabled.')
 
-def validate_license(ctera_license):
-    try:
-        infer(ctera_license)
-    except InputError as error:
-        logging.getLogger().error('Connection failed. Invalid license type. %s', {'license': ctera_license})
-        raise error
+    def _connect_to_services(self, param, ctera_license):
+        task = self.attach(param)
+        try:
+            TaskManager.wait(self._gateway, task)
+            logging.getLogger().info("Connected to Portal.")
+        except TaskManager.TaskError as error:
+            description = error.task.description
+            logging.getLogger().error("Connection failed. Reason: %s", description)
+            raise CTERAException("Connection failed", None, reason=description)
+        self._gateway.licenses.apply(ctera_license)
 
+    @staticmethod
+    def _validate_license(ctera_license):
+        try:
+            Licenses.infer(ctera_license)
+        except InputError as error:
+            logging.getLogger().error('Connection failed. Invalid license type. %s', {'license': ctera_license})
+            raise error
 
-def check_cttp_traffic(ctera_host, address, port=995):
-    tcp_conn_status = tcp_connect(ctera_host, address=address, port=port)
-    if not tcp_conn_status:
-        logging.getLogger().error("Unable to establish connection over port %s", str(port))
-        raise CTERAConnectionError('Unable to establish connection', None, host=address, port=port, protocol='CTTP')
+    def _check_cttp_traffic(self, address, port=995):
+        tcp_conn_status = self._gateway.network.tcp_connect(address=address, port=port)
+        if not tcp_conn_status:
+            logging.getLogger().error("Unable to establish connection over port %s", str(port))
+            raise CTERAConnectionError('Unable to establish connection', None, host=address, port=port, protocol='CTTP')
 
+    def _check_connection(self, server, trust_cert=None):
+        param = Object()
+        param.server = server
+        param.trustCertificate = trust_cert
+        obj = self._gateway.execute('/status/services', 'isWebSsoEnabled', param)
+        if Services.check_web_sso(obj):
+            return
+        self._handle_untrusted_cert(server, obj)
 
-def check_connection(ctera_host, server, trust_cert=None):
-    param = Object()
-    param.server = server
-    param.trustCertificate = trust_cert
-    obj = ctera_host.execute('/status/services', 'isWebSsoEnabled', param)
-    if check_web_sso(obj):
-        return
-    handle_untrusted_cert(ctera_host, server, obj)
+    @staticmethod
+    def check_web_sso(obj):
+        try:
+            if obj.result.hasWebSSO:
+                message = "Connection failed. You must activate this Gateway using an activation code."
+                logging.getLogger().error(message)
+                raise CTERAException(message)
 
+            if not obj.result.hasWebSSO and obj.rc == "connectOK":
+                return True
+            raise CTERAException("Connection failed", None, reason=obj.rc)
+        except AttributeError:
+            pass
 
-def check_web_sso(obj):
-    try:
-        if obj.result.hasWebSSO:
-            message = "Connection failed. You must activate this Gateway using an activation code."
-            logging.getLogger().error(message)
-            raise CTERAException(message)
+        return False
 
-        if not obj.result.hasWebSSO and obj.rc == "connectOK":
-            return True
-        raise CTERAException("Connection failed", None, reason=obj.rc)
-    except AttributeError:
-        pass
+    def _handle_untrusted_cert(self, server, obj):
+        try:
+            if obj.rc in ['UntrustedCert', 'UntrustedCA']:
+                if config.connect['ssl'] == 'Consent':
+                    logging.getLogger().warning(msg=obj.msg)
+                    proceed = ask("Proceed connecting '" + self._gateway.host() + "' to " + server + '?')
+                if config.connect['ssl'] == 'Trust' or proceed:
+                    return self.check_connection(server, trust_cert=True)
+        except AttributeError:
+            pass
+        return False
 
-    return False
-
-
-def handle_untrusted_cert(ctera_host, server, obj):
-    try:
-        if obj.rc in ['UntrustedCert', 'UntrustedCA']:
-            if config.connect['ssl'] == 'Consent':
-                logging.getLogger().warning(msg=obj.msg)
-                proceed = ask("Proceed connecting '" + ctera_host.host() + "' to " + server + '?')
-            if config.connect['ssl'] == 'Trust' or proceed:
-                return check_connection(ctera_host, server, trust_cert=True)
-    except AttributeError:
-        pass
-    return False
-
-
-def attach(ctera_host, param):
-    logging.getLogger().info("Connecting to Portal. %s", {'server': param.server, 'user': param.user})
-    obj = ctera_host.execute("/status/services", "attachAndSave", param)
-    return obj.id
-
-
-def reconnect(ctera_host):
-    ctera_host.execute("/status/services", "reconnect", None)
-
-
-def disconnect(ctera_host):
-    ctera_host.put('/config/services', None)
-
-
-def enable_sso(ctera_host):
-    logging.getLogger().info('Enabling single sign-on from CTERA Portal.')
-    ctera_host.put('/config/gui/adminRemoteAccessSSO', True)
-    logging.getLogger().info('Single sign-on enabled.')
+    def attach(self, param):
+        logging.getLogger().info("Connecting to Portal. %s", {'server': param.server, 'user': param.user})
+        obj = self._gateway.execute("/status/services", "attachAndSave", param)
+        return obj.id

--- a/cterasdk/edge/shares.py
+++ b/cterasdk/edge/shares.py
@@ -49,7 +49,7 @@ class Shares(BaseCommand):
         param.acl = []
         for entry in acl:
             if len(entry) != 3:
-                raise InputError('Invalid input', repr(entry), '[("type", "name", "perm"), ...]')
+                Shares._invalid_ace(entry)
             Shares._add_share_acl_rule(param.acl, entry[0], entry[1], entry[2])
 
         try:
@@ -58,6 +58,14 @@ class Shares(BaseCommand):
         except Exception as error:
             logging.getLogger().error("Share creation failed.")
             raise CTERAException('Share creation failed', error)
+            
+    def set_acl(self, name, acl):
+        param = []
+        for entry in acl:
+            if len(entry) != 3:
+                Shares._invalid_ace(entry)
+            Shares._add_share_acl_rule(param, entry[0], entry[1], entry[2])
+        self._gateway.put('/config/fileservices/share/' + name + '/acl', param)
 
     def add_acl(self, name, acl):
         current_acl = self._gateway.get('/config/fileservices/share/' + name + '/acl')
@@ -66,7 +74,7 @@ class Shares(BaseCommand):
         for entry in acl:
             temp_acl = []
             if len(entry) != 3:
-                raise InputError('Invalid input', repr(entry), '[("type", "name", "perm"), ...]')
+                Shares._invalid_ace(entry)
             Shares._add_share_acl_rule(temp_acl, entry[0], entry[1], entry[2])
             entry_key = entry[0] + '#' + entry[1]
             new_acl_dict[entry_key] = temp_acl[0]
@@ -163,3 +171,7 @@ class Shares(BaseCommand):
         acls.append(ace)
 
         return acls
+    
+    @staticmethod
+    def _invalid_ace(entry):
+        raise InputError('Invalid input', repr(entry), '[("type", "name", "perm"), ...]')

--- a/cterasdk/edge/shares.py
+++ b/cterasdk/edge/shares.py
@@ -60,6 +60,16 @@ class Shares(BaseCommand):
             raise CTERAException('Share creation failed', error)
             
     def set_acl(self, name, acl):
+        """
+        Set a network share's access control entries.
+        
+        :param name: the name of a network share
+        :param acl: a list of 3-tuple access control entries
+        :type name: str
+        :type acl: list[tuple(str, str, str)]
+        
+        .. warning: this method will override the existing access control entries
+        """
         param = []
         for entry in acl:
             if len(entry) != 3:

--- a/cterasdk/edge/shell.py
+++ b/cterasdk/edge/shell.py
@@ -2,15 +2,18 @@ import logging
 
 from . import taskmgr as TaskManager
 from ..exception import CTERAException
+from .base_command import BaseCommand
 
 
-def run_shell_command(ctera_host, shell_command):
-    logging.getLogger().info("Executing shell command. %s", {'shell_command': shell_command})
+class Shell(BaseCommand):
 
-    task = ctera_host.execute("/config/device", "bgshell", shell_command)
-    try:
-        task = TaskManager.wait(ctera_host, task)
-        logging.getLogger().info("Shell command executed. %s", {'shell_command': shell_command})
-        return task.result.result
-    except TaskManager.TaskError as error:
-        raise CTERAException('An error occurred while executing task', error)
+    def run_command(self, shell_command):
+        logging.getLogger().info("Executing shell command. %s", {'shell_command': shell_command})
+
+        task = self._gateway.execute("/config/device", "bgshell", shell_command)
+        try:
+            task = TaskManager.wait(self._gateway, task)
+            logging.getLogger().info("Shell command executed. %s", {'shell_command': shell_command})
+            return task.result.result
+        except TaskManager.TaskError as error:
+            raise CTERAException('An error occurred while executing task', error)

--- a/cterasdk/edge/smb.py
+++ b/cterasdk/edge/smb.py
@@ -2,40 +2,39 @@ import logging
 
 from .enum import Mode, CIFSPacketSigning
 from ..exception import CTERAException, InputError
+from .base_command import BaseCommand
 
 
-def enable(ctera_host):
-    logging.getLogger().info('Enabling SMB server.')
-    ctera_host.put('/config/fileservices/cifs/mode', Mode.Enabled)
-    logging.getLogger().info('SMB server enabled.')
+class SMB(BaseCommand):
 
+    def enable(self):
+        logging.getLogger().info('Enabling SMB server.')
+        self._gateway.put('/config/fileservices/cifs/mode', Mode.Enabled)
+        logging.getLogger().info('SMB server enabled.')
 
-def enable_abe(ctera_host):
-    logging.getLogger().info('Enabling ABE.')
-    ctera_host.put('/config/fileservices/cifs/hideUnreadable', True)
-    logging.getLogger().info('Access Based Enumeration (ABE) enabled.')
+    def enable_abe(self):
+        logging.getLogger().info('Enabling ABE.')
+        self._gateway.put('/config/fileservices/cifs/hideUnreadable', True)
+        logging.getLogger().info('Access Based Enumeration (ABE) enabled.')
 
+    def disable_abe(self):
+        logging.getLogger().info('Disabling ABE.')
+        self._gateway.put('/config/fileservices/cifs/hideUnreadable', False)
+        logging.getLogger().info('Access Based Enumeration (ABE) disabled.')
 
-def disable_abe(ctera_host):
-    logging.getLogger().info('Disabling ABE.')
-    ctera_host.put('/config/fileservices/cifs/hideUnreadable', False)
-    logging.getLogger().info('Access Based Enumeration (ABE) disabled.')
+    def set_packet_signing(self, packet_signing):
+        options = [v for k, v in CIFSPacketSigning.__dict__.items() if not k.startswith('_')]
+        if packet_signing not in options:
+            raise InputError('Invalid packet signing option', packet_signing, options)
+        logging.getLogger().info('Updating SMB packet signing configuration.')
+        try:
+            self._gateway.put('/config/fileservices/cifs/packetSigning', packet_signing)
+            logging.getLogger().info('SMB packet signing configuration updated. %s', {'packet_signing': packet_signing})
+        except CTERAException as error:
+            logging.getLogger().error('Failed to update SMB packet signing configuration.')
+            raise CTERAException('Invalid packet signing co', error)
 
-
-def set_packet_signing(ctera_host, packet_signing):
-    options = [v for k, v in CIFSPacketSigning.__dict__.items() if not k.startswith('_')]
-    if packet_signing not in options:
-        raise InputError('Invalid packet signing option', packet_signing, options)
-    logging.getLogger().info('Updating SMB packet signing configuration.')
-    try:
-        ctera_host.put('/config/fileservices/cifs/packetSigning', packet_signing)
-        logging.getLogger().info('SMB packet signing configuration updated. %s', {'packet_signing': packet_signing})
-    except CTERAException as error:
-        logging.getLogger().error('Failed to update SMB packet signing configuration.')
-        raise CTERAException('Invalid packet signing co', error)
-
-
-def disable(ctera_host):
-    logging.getLogger().info('Disabling SMB server.')
-    ctera_host.put('/config/fileservices/cifs/mode', Mode.Disabled)
-    logging.getLogger().info('SMB server disabled.')
+    def disable(self):
+        logging.getLogger().info('Disabling SMB server.')
+        self._gateway.put('/config/fileservices/cifs/mode', Mode.Disabled)
+        logging.getLogger().info('SMB server disabled.')

--- a/cterasdk/edge/support.py
+++ b/cterasdk/edge/support.py
@@ -4,7 +4,7 @@ import logging
 from ..exception import InputError
 from ..lib import FileSystem
 from .. import config
-from .cli import run_cli_command
+from .base_command import BaseCommand
 
 
 class DebugLevel:
@@ -42,20 +42,21 @@ class DebugLevel:
     caching = "caching"
 
 
-def set_debug_level(ctera_host, *levels):
-    options = [v for k, v in DebugLevel.__dict__.items() if not k.startswith('_')]
-    cli_command = 'dbg level'
-    for level in levels:
-        if level not in options:
-            raise InputError('Invalid debug level', level, options)
-        cli_command = cli_command + ' ' + level
-    return run_cli_command(ctera_host, cli_command)
+class Support(BaseCommand):
 
+    def set_debug_level(self, *levels):
+        options = [v for k, v in DebugLevel.__dict__.items() if not k.startswith('_')]
+        cli_command = 'dbg level'
+        for level in levels:
+            if level not in options:
+                raise InputError('Invalid debug level', level, options)
+            cli_command = cli_command + ' ' + level
+        return self._gateway.cli.run_command(cli_command)
 
-def get_support_report(ctera_host):
-    dirpath = config.filesystem['dl']
-    filename = 'Support-' + ctera_host.host() + datetime.now().strftime('_%Y-%m-%dT%H_%M_%S') + '.zip'
-    logging.getLogger().info('Downloading support report. %s', {'host': ctera_host.host()})
-    handle = ctera_host.openfile(ctera_host._api(), '/supportreport', params={})  # pylint: disable=protected-access
-    filepath = FileSystem.instance().save(dirpath, filename, handle)
-    logging.getLogger().info('Support report downloaded. %s', {'filepath': filepath})
+    def get_support_report(self):
+        dirpath = config.filesystem['dl']
+        filename = 'Support-' + self._gateway.host() + datetime.now().strftime('_%Y-%m-%dT%H_%M_%S') + '.zip'
+        logging.getLogger().info('Downloading support report. %s', {'host': self._gateway.host()})
+        handle = self._gateway.openfile('/supportreport')
+        filepath = FileSystem.instance().save(dirpath, filename, handle)
+        logging.getLogger().info('Support report downloaded. %s', {'filepath': filepath})

--- a/cterasdk/edge/sync.py
+++ b/cterasdk/edge/sync.py
@@ -2,56 +2,57 @@ import logging
 
 from ..lib import track, ErrorStatus
 from .enum import Mode, SyncStatus, Acl
+from .base_command import BaseCommand
 
 
-def suspend(CTERAHost):
-    logging.getLogger().info("Suspending cloud sync.")
-    CTERAHost.put('/config/cloudsync/mode', Mode.Disabled)
-    logging.getLogger().info("Cloud sync suspended.")
+class Sync(BaseCommand):
 
+    def suspend(self):
+        logging.getLogger().info("Suspending cloud sync.")
+        self._gateway.put('/config/cloudsync/mode', Mode.Disabled)
+        logging.getLogger().info("Cloud sync suspended.")
 
-def unsuspend(CTERAHost):
-    logging.getLogger().info("Unsuspending cloud sync.")
-    CTERAHost.put('/config/cloudsync/mode', Mode.Enabled)
-    try:
-        ref = '/proc/cloudsync/serviceStatus/id'
-        track(
-            CTERAHost,
-            ref,
-            [
-                SyncStatus.Synced,
-                SyncStatus.Syncing,
-                SyncStatus.Scanning
-            ],
-            [
-                SyncStatus.ConnectingFolders,
-                SyncStatus.InitializingConnection
-            ],
-            [
-                SyncStatus.DisconnectedPortal,
-                SyncStatus.Unlicensed,
-                SyncStatus.Off
-            ],
-            [
-                SyncStatus.ServiceUnavailable,
-                SyncStatus.VolumeUnavailable,
-                SyncStatus.ShouldSupportWinNtAcl,
-                SyncStatus.InternalError,
-                SyncStatus.ClocksOutOfSync,
-                SyncStatus.NoFolder
-            ]
-        )
-        logging.getLogger().info('Unsuspended cloud sync.')
-    except ErrorStatus as error:
-        if error.status == SyncStatus.ShouldSupportWinNtAcl:
-            logging.getLogger().warning('Windows ACL enabled folder cannot be synchronized to this device.')
-            CTERAHost.put('/config/fileservices/share/cloud/access', Acl.WindowsNT)
-            logging.getLogger().info('Updated network share access. %s', {'share': 'cloud', 'access': Acl.WindowsNT})
-        else:
-            logging.getLogger().error("An error occurred while unsuspendeding sync. %s", {'status': error.status})
+    def unsuspend(self):
+        logging.getLogger().info("Unsuspending cloud sync.")
+        self._gateway.put('/config/cloudsync/mode', Mode.Enabled)
+        try:
+            ref = '/proc/cloudsync/serviceStatus/id'
+            track(
+                self._gateway,
+                ref,
+                [
+                    SyncStatus.Synced,
+                    SyncStatus.Syncing,
+                    SyncStatus.Scanning
+                ],
+                [
+                    SyncStatus.ConnectingFolders,
+                    SyncStatus.InitializingConnection
+                ],
+                [
+                    SyncStatus.DisconnectedPortal,
+                    SyncStatus.Unlicensed,
+                    SyncStatus.Off
+                ],
+                [
+                    SyncStatus.ServiceUnavailable,
+                    SyncStatus.VolumeUnavailable,
+                    SyncStatus.ShouldSupportWinNtAcl,
+                    SyncStatus.InternalError,
+                    SyncStatus.ClocksOutOfSync,
+                    SyncStatus.NoFolder
+                ]
+            )
+            logging.getLogger().info('Unsuspended cloud sync.')
+        except ErrorStatus as error:
+            if error.status == SyncStatus.ShouldSupportWinNtAcl:
+                logging.getLogger().warning('Windows ACL enabled folder cannot be synchronized to this device.')
+                self._gateway.put('/config/fileservices/share/cloud/access', Acl.WindowsNT)
+                logging.getLogger().info('Updated network share access. %s', {'share': 'cloud', 'access': Acl.WindowsNT})
+            else:
+                logging.getLogger().error("An error occurred while unsuspendeding sync. %s", {'status': error.status})
 
-
-def refresh(CTERAHost):
-    logging.getLogger().info("Refreshing cloud folders.")
-    CTERAHost.execute("/config/cloudsync/cloudExtender", "refreshPaths", None)
-    logging.getLogger().info("Completed refreshing cloud folders.")
+    def refresh(self):
+        logging.getLogger().info("Refreshing cloud folders.")
+        self._gateway.execute("/config/cloudsync/cloudExtender", "refreshPaths", None)
+        logging.getLogger().info("Completed refreshing cloud folders.")

--- a/cterasdk/edge/syslog.py
+++ b/cterasdk/edge/syslog.py
@@ -1,32 +1,34 @@
 import logging
 
 from ..common import Object
-from .enum import Mode
+from . import enum
+from .base_command import BaseCommand
 
 
-def enable(ctera_host, server, port, proto, minSeverity):
-    obj = Object()
-    obj.mode = Mode.Enabled
-    obj.server = server
-    obj.port = port
-    obj.proto = proto
-    obj.minSeverity = minSeverity
+class Syslog(BaseCommand):
 
-    logging.getLogger().info("Configuring syslog server.")
-    ctera_host.put('/config/logging/syslog', obj)
-    logging.getLogger().info(
-        "Syslog server configured. %s",
-        {'server': server, 'port': port, 'protocol': proto, 'minSeverity': minSeverity}
-    )
+    def enable(self, server, port=514, proto=enum.IPProtocol.UDP, minSeverity=enum.Severity.INFO):
+        obj = Object()
+        obj.mode = enum.Mode.Enabled
+        obj.server = server
+        obj.port = port
+        obj.proto = proto
+        obj.minSeverity = minSeverity
 
+        logging.getLogger().info("Configuring syslog server.")
+        self._gateway.put('/config/logging/syslog', obj)
+        logging.getLogger().info(
+            "Syslog server configured. %s",
+            {'server': server, 'port': port, 'protocol': proto, 'minSeverity': minSeverity}
+        )
 
-def disable(ctera_host):
-    '''
-    {
-        "desc": "Disable log forwarding over syslog"
-    }
-    '''
+    def disable(self):
+        '''
+        {
+            "desc": "Disable log forwarding over syslog"
+        }
+        '''
 
-    logging.getLogger().info("Disabling syslog server.")
-    ctera_host.put('/config/logging/syslog/mode', Mode.Disabled)
-    logging.getLogger().info("Syslog server disabled.")
+        logging.getLogger().info("Disabling syslog server.")
+        self._gateway.put('/config/logging/syslog/mode', enum.Mode.Disabled)
+        logging.getLogger().info("Syslog server disabled.")

--- a/cterasdk/edge/telnet.py
+++ b/cterasdk/edge/telnet.py
@@ -2,30 +2,32 @@ import logging
 
 from ..common import Object
 from ..exception import CTERAException
+from .base_command import BaseCommand
 
 
-def enable(ctera_host, code):
-    status = ctera_host.get('/status/device')
-    version = status.runningFirmware
-    if version.count('.') == 2:
-        version = version + '.0'
+class Telnet(BaseCommand):
 
-    param = Object()
-    param.code = code
+    def enable(self, code):
+        status = self._gateway.get('/status/device')
+        version = status.runningFirmware
+        if version.count('.') == 2:
+            version = version + '.0'
 
-    logging.getLogger().info("Enabling telnet access.")
+        param = Object()
+        param.code = code
 
-    response = ctera_host.execute("/config/device", "startTelnetd", param)
-    if response == 'telnetd already running':
-        logging.getLogger().info("Telnet access already enabled.")
-    elif response != "OK":
-        logging.getLogger().error("Failed enabling telnet access. %s", {'reason': response})
-        raise CTERAException("Failed enabling telnet access", None, reason=response)
-    else:
-        logging.getLogger().info("Telnet access enabled.")
+        logging.getLogger().info("Enabling telnet access.")
 
+        response = self._gateway.execute("/config/device", "startTelnetd", param)
+        if response == 'telnetd already running':
+            logging.getLogger().info("Telnet access already enabled.")
+        elif response != "OK":
+            logging.getLogger().error("Failed enabling telnet access. %s", {'reason': response})
+            raise CTERAException("Failed enabling telnet access", None, reason=response)
+        else:
+            logging.getLogger().info("Telnet access enabled.")
 
-def disable(ctera_host):
-    logging.getLogger().info("Disabling telnet access.")
-    ctera_host.execute("/config/device", "stopTelnetd")
-    logging.getLogger().info("Telnet access disabled.")
+    def disable(self):
+        logging.getLogger().info("Disabling telnet access.")
+        self._gateway.execute("/config/device", "stopTelnetd")
+        logging.getLogger().info("Telnet access disabled.")

--- a/cterasdk/edge/timezone.py
+++ b/cterasdk/edge/timezone.py
@@ -1,9 +1,12 @@
 import logging
+from .base_command import BaseCommand
 
 
-def set_timezone(ctera_host, timezone):
-    logging.getLogger().info("Updating timezone. %s", {'timezone': timezone})
+class Timezone(BaseCommand):
 
-    ctera_host.put('/config/time/TimeZone', timezone)
+    def set_timezone(self, timezone):
+        logging.getLogger().info("Updating timezone. %s", {'timezone': timezone})
 
-    logging.getLogger().info("Timezone updated. %s", {'timezone': timezone})
+        self._gateway.put('/config/time/TimeZone', timezone)
+
+        logging.getLogger().info("Timezone updated. %s", {'timezone': timezone})

--- a/cterasdk/edge/uri.py
+++ b/cterasdk/edge/uri.py
@@ -6,10 +6,10 @@ from ..exception import CTERAException
 def api(Gateway):
     session = Gateway.session()
     if session.local():                             # direct access, via IP, hostname or FQDN
-        return local(Gateway._baseurl())  # pylint: disable=protected-access
+        return local(Gateway.baseurl())
 
     if session.remote():
-        baseurl = Gateway._Portal._baseurl()  # pylint: disable=protected-access
+        baseurl = Gateway._Portal.base_api_url()  # pylint: disable=protected-access
         device = Gateway.host()
         if session.remote_access():
             return remote_access(baseurl, device)   # remote: Gateway.remote_access()
@@ -36,12 +36,12 @@ def remote_access(baseurl, device):
 def files(Gateway):
     session = Gateway.session()
     if session.local():
-        baseurl = Gateway._baseurl()  # pylint: disable=protected-access
+        baseurl = Gateway.baseurl()
         return '%s/localFiles' % (baseurl)
 
     if session.remote():
         if session.remote_access():
-            baseurl = Gateway._Portal._baseurl()  # pylint: disable=protected-access
+            baseurl = Gateway._Portal.base_api_url()  # pylint: disable=protected-access
             device = Gateway.host()
             return '%s/devices/%s/localFiles' % (baseurl, device)
     raise CTERAException('Invalid connection type', session)

--- a/cterasdk/edge/uri.py
+++ b/cterasdk/edge/uri.py
@@ -9,7 +9,7 @@ def api(Gateway):
         return local(Gateway.baseurl())
 
     if session.remote():
-        baseurl = Gateway._Portal.base_api_url()  # pylint: disable=protected-access
+        baseurl = Gateway._Portal.base_portal_url  # pylint: disable=protected-access
         device = Gateway.host()
         if session.remote_access():
             return remote_access(baseurl, device)   # remote: Gateway.remote_access()
@@ -41,7 +41,7 @@ def files(Gateway):
 
     if session.remote():
         if session.remote_access():
-            baseurl = Gateway._Portal.base_api_url()  # pylint: disable=protected-access
+            baseurl = Gateway._Portal.base_portal_url  # pylint: disable=protected-access
             device = Gateway.host()
             return '%s/devices/%s/localFiles' % (baseurl, device)
     raise CTERAException('Invalid connection type', session)

--- a/cterasdk/edge/users.py
+++ b/cterasdk/edge/users.py
@@ -2,43 +2,44 @@ import logging
 
 from ..common import Object
 from ..exception import CTERAException
+from .base_command import BaseCommand
 
 
-def add_first_user(ctera_host, username, password, email):
-    info = ctera_host.get('/nosession/logininfo')
-    if info.isfirstlogin:
+class Users(BaseCommand):
+
+    def add_first_user(self, username, password, email=''):
+        info = self._gateway.get('/nosession/logininfo')
+        if info.isfirstlogin:
+            user = Object()
+            user.username = username
+            user.password = password
+            user.email = email
+            self._gateway.post('/nosession/createfirstuser', user)
+            logging.getLogger().info('User created. %s', {'user': username})
+        else:
+            logging.getLogger().info('Skipping. root account already exists.')
+        self._gateway.login.login(username, password)
+
+    def add(self, username, password, fullName=None, email=None, uid=None):
         user = Object()
         user.username = username
         user.password = password
+        user.fullName = fullName
         user.email = email
-        ctera_host.post('/nosession/createfirstuser', user)
-        logging.getLogger().info('User created. %s', {'user': username})
-    else:
-        logging.getLogger().info('Skipping. root account already exists.')
-    ctera_host.login(username, password)
+        user.uid = uid
+        try:
+            response = self._gateway.add('/config/auth/users', user)
+            logging.getLogger().info("User created. %s", {'username': user.username})
+            return response
+        except CTERAException as error:
+            logging.getLogger().error("User creation failed.")
+            raise CTERAException('User creation failed', error)
 
-
-def add(ctera_host, username, password, fullName, email, uid):
-    user = Object()
-    user.username = username
-    user.password = password
-    user.fullName = fullName
-    user.email = email
-    user.uid = uid
-    try:
-        response = ctera_host.add('/config/auth/users', user)
-        logging.getLogger().info("User created. %s", {'username': user.username})
-        return response
-    except CTERAException as error:
-        logging.getLogger().error("User creation failed.")
-        raise CTERAException('User creation failed', error)
-
-
-def delete(ctera_host, username):
-    try:
-        response = ctera_host.delete('/config/auth/users/' + username)
-        logging.getLogger().info("User deleted. %s", {'username': username})
-        return response
-    except Exception as error:
-        logging.getLogger().error("User deletion failed.")
-        raise CTERAException('User deletion failed', error)
+    def delete(self, username):
+        try:
+            response = self._gateway.delete('/config/auth/users/' + username)
+            logging.getLogger().info("User deleted. %s", {'username': username})
+            return response
+        except Exception as error:
+            logging.getLogger().error("User deletion failed.")
+            raise CTERAException('User deletion failed', error)

--- a/cterasdk/edge/volumes.py
+++ b/cterasdk/edge/volumes.py
@@ -5,155 +5,152 @@ from .enum import VolumeStatus
 from ..common import Object
 from ..exception import CTERAException, InputError
 from ..lib import track
+from .base_command import BaseCommand
 
 
-def add(CTERAHost, name, size, filesystem, device, passphrase):
-    storage_devices = devices(CTERAHost)
-    device_name, device_size = device_volume(device, storage_devices)
-    storage_volume_size = volume_size(size, device_name, device_size)
-    filesystem = volume_filesystem(filesystem)
+class Volumes(BaseCommand):
 
-    param = Object()
-    param.name = name
-    param.device = device_name
-    param.size = storage_volume_size
-    param.fileSystemType = filesystem
+    def add(self, name, size=None, filesystem='xfs', device=None, passphrase=None):
+        storage_devices = self._devices()
+        device_name, device_size = Volumes._device_volume(device, storage_devices)
+        storage_volume_size = Volumes._volume_size(size, device_name, device_size)
+        filesystem = Volumes._volume_filesystem(filesystem)
 
-    if passphrase is not None:
-        param.encrypted = True
-        param.encPassphrase = passphrase
+        param = Object()
+        param.name = name
+        param.device = device_name
+        param.size = storage_volume_size
+        param.fileSystemType = filesystem
 
-    logging.getLogger().info(
-        'Creating volume. %s',
-        {'name': name, 'device': device_name, 'size': size, 'filesystem': filesystem, 'passphrase': passphrase}
-    )
+        if passphrase is not None:
+            param.encrypted = True
+            param.encPassphrase = passphrase
 
-    ref = '/status/storage/volumes/' + param.name + '/status'
+        logging.getLogger().info(
+            'Creating volume. %s',
+            {'name': name, 'device': device_name, 'size': size, 'filesystem': filesystem, 'passphrase': passphrase}
+        )
 
-    response = CTERAHost.add('/config/storage/volumes', param)
+        ref = '/status/storage/volumes/' + param.name + '/status'
 
-    status = track(
-        CTERAHost,
-        ref,
-        [VolumeStatus.Ok],
-        [VolumeStatus.Formatting],
-        [VolumeStatus.Mounting, VolumeStatus.Checking, VolumeStatus.Repairing], [VolumeStatus.Corrupted, VolumeStatus.Unknown]
-    )
+        response = self._gateway.add('/config/storage/volumes', param)
 
-    logging.getLogger().info('Volume created. %s', {'name': name, 'size': size, 'status': status})
+        status = track(
+            self._gateway,
+            ref,
+            [VolumeStatus.Ok],
+            [VolumeStatus.Formatting],
+            [VolumeStatus.Mounting, VolumeStatus.Checking, VolumeStatus.Repairing], [VolumeStatus.Corrupted, VolumeStatus.Unknown]
+        )
 
-    return response
-
-
-def devices(CTERAHost):
-    arrays = CTERAHost.get('/status/storage/arrays')
-    drives = CTERAHost.get('/status/storage/disks')
-
-    ctera_devices = {}
-    for array in arrays:
-        ctera_devices[array.name] = array.availableCapacity
-
-    for drive in drives:
-        ctera_devices[drive.name] = drive.availableCapacity
-
-    if len(ctera_devices) == 0:
-        logging.getLogger().error('Could not find any drives or arrays.')
-
-        raise CTERAException('Could not find any drives or arrays')
-
-    return ctera_devices
-
-
-def device_volume(device_name, ctera_devices):
-    if device_name is not None:
-        device_size = ctera_devices.get(device_name)
-        if device_size is not None:
-            logging.getLogger().debug('Found drive. %s', {'name': device_name, 'size': device_size})
-            return (device_name, device_size)
-
-        device_names = [k for k, v in ctera_devices.items()]
-        logging.getLogger().error('Invalid device name. %s', {'name': device_name})
-        raise InputError('Invalid device name', device_name, device_names)
-
-    if len(ctera_devices) == 1:
-        device_name, device_size = ctera_devices.popitem()
-        logging.getLogger().debug('Found drive. %s', {'name': device_name, 'size': device_size})
-        return device_name, device_size
-
-    device_names = [k for k, v in ctera_devices.items()]
-    logging.getLogger().error('You must specify a drive or an array name. %s', {'options': device_names})
-    raise CTERAException('You must specify a drive or an array name', None, options=device_names)
-
-
-def volume_size(size, device_name, device_size):
-    if size is not None:
-        if size > device_size:
-            logging.getLogger().error('You cannot exceed the available storage capacity. %s', {'size': size, 'free_size': device_size})
-            raise InputError("You cannot exceed the available storage capacity", size, device_size)
-        return size
-
-    if device_size > 0:
-        logging.getLogger().warning('You did not specify a volume size.')
-        logging.getLogger().warning('Allocating available storage capacity. %s', {'name': device_name, 'free_size': device_size})
-        return device_size
-
-    logging.getLogger().error('Insufficient storage space. %s', {'name': device_name})
-    raise CTERAException('Insufficient storage space', None, device=device_name, free_size=device_size)
-
-
-def volume_filesystem(filesystem):
-    filesystem = filesystem.lower()
-    if filesystem in ['xfs', 'next3', 'ext3']:
-        return filesystem
-    raise InputError('Invalid file system type', filesystem, ['xfs', 'next3', 'ext3'])
-
-
-def delete(ctera_host, name):
-    wait_pending_mount(ctera_host, name)
-    try:
-        logging.getLogger().info('Deleting volume. %s', {'name': name})
-
-        response = ctera_host.delete('/config/storage/volumes/' + name)
-
-        logging.getLogger().info("Volume deleted. %s", {'name': name})
+        logging.getLogger().info('Volume created. %s', {'name': name, 'size': size, 'status': status})
 
         return response
-    except CTERAException as error:
-        logging.getLogger().error("Volume deletion failed. %s", {'name': name})
-        raise CTERAException('Volume deletion falied', error)
 
+    def delete(self, name):
+        self._wait_pending_mount(name)
+        try:
+            logging.getLogger().info('Deleting volume. %s', {'name': name})
 
-def delete_all(ctera_host):
-    wait_pending_filesystem_mounts(ctera_host)
+            response = self._gateway.delete('/config/storage/volumes/' + name)
 
-    volumes = ctera_host.get('/config/storage/volumes')
-    volume_count = len(volumes)
-    if volume_count > 0:
-        for volume in volumes:
-            delete(ctera_host, volume.name)
-    else:
-        logging.getLogger().info('No volumes found.')
+            logging.getLogger().info("Volume deleted. %s", {'name': name})
 
+            return response
+        except CTERAException as error:
+            logging.getLogger().error("Volume deletion failed. %s", {'name': name})
+            raise CTERAException('Volume deletion falied', error)
 
-def wait_pending_filesystem_mounts(CTERAHost):
-    logging.getLogger().debug('Checking for pending mount tasks.')
+    def delete_all(self):
+        self._wait_pending_filesystem_mounts()
 
-    tasks = TaskManager.running(CTERAHost)
-    for mount in tasks:
-        if mount.name.startswith('Mounting'):
-            wait_mount(CTERAHost, mount.id)
+        volumes = self._gateway.get('/config/storage/volumes')
+        volume_count = len(volumes)
+        if volume_count > 0:
+            for volume in volumes:
+                self.delete(volume.name)
+        else:
+            logging.getLogger().info('No volumes found.')
 
+    def _devices(self):
+        arrays = self._gateway.get('/status/storage/arrays')
+        drives = self._gateway.get('/status/storage/disks')
 
-def wait_pending_mount(CTERAHost, volume):
-    logging.getLogger().debug('Checking for pending mount tasks. %s', {'volume': volume})
+        ctera_devices = {}
+        for array in arrays:
+            ctera_devices[array.name] = array.availableCapacity
 
-    tasks = TaskManager.by_name(CTERAHost, ' '.join(['Mounting', volume, 'file system']))
-    for mount in tasks:
-        wait_mount(CTERAHost, mount.id)
+        for drive in drives:
+            ctera_devices[drive.name] = drive.availableCapacity
 
+        if len(ctera_devices) == 0:
+            logging.getLogger().error('Could not find any drives or arrays.')
 
-def wait_mount(CTERAHost, tid):
-    try:
-        TaskManager.wait(CTERAHost, tid)
-    except TaskManager.TaskError:
-        logging.getLogger().debug('Failed mounting volume. %s', {'tid': tid})
+            raise CTERAException('Could not find any drives or arrays')
+
+        return ctera_devices
+
+    @staticmethod
+    def _device_volume(device_name, ctera_devices):
+        if device_name is not None:
+            device_size = ctera_devices.get(device_name)
+            if device_size is not None:
+                logging.getLogger().debug('Found drive. %s', {'name': device_name, 'size': device_size})
+                return (device_name, device_size)
+
+            device_names = [k for k, v in ctera_devices.items()]
+            logging.getLogger().error('Invalid device name. %s', {'name': device_name})
+            raise InputError('Invalid device name', device_name, device_names)
+
+        if len(ctera_devices) == 1:
+            device_name, device_size = ctera_devices.popitem()
+            logging.getLogger().debug('Found drive. %s', {'name': device_name, 'size': device_size})
+            return device_name, device_size
+
+        device_names = [k for k, v in ctera_devices.items()]
+        logging.getLogger().error('You must specify a drive or an array name. %s', {'options': device_names})
+        raise CTERAException('You must specify a drive or an array name', None, options=device_names)
+
+    @staticmethod
+    def _volume_size(size, device_name, device_size):
+        if size is not None:
+            if size > device_size:
+                logging.getLogger().error('You cannot exceed the available storage capacity. %s', {'size': size, 'free_size': device_size})
+                raise InputError("You cannot exceed the available storage capacity", size, device_size)
+            return size
+
+        if device_size > 0:
+            logging.getLogger().warning('You did not specify a volume size.')
+            logging.getLogger().warning('Allocating available storage capacity. %s', {'name': device_name, 'free_size': device_size})
+            return device_size
+
+        logging.getLogger().error('Insufficient storage space. %s', {'name': device_name})
+        raise CTERAException('Insufficient storage space', None, device=device_name, free_size=device_size)
+
+    @staticmethod
+    def _volume_filesystem(filesystem):
+        filesystem = filesystem.lower()
+        if filesystem in ['xfs', 'next3', 'ext3']:
+            return filesystem
+        raise InputError('Invalid file system type', filesystem, ['xfs', 'next3', 'ext3'])
+
+    def _wait_pending_filesystem_mounts(self):
+        logging.getLogger().debug('Checking for pending mount tasks.')
+
+        tasks = TaskManager.running(self._gateway)
+        for mount in tasks:
+            if mount.name.startswith('Mounting'):
+                self._wait_mount(mount.id)
+
+    def _wait_pending_mount(self, volume):
+        logging.getLogger().debug('Checking for pending mount tasks. %s', {'volume': volume})
+
+        tasks = TaskManager.by_name(self._gateway, ' '.join(['Mounting', volume, 'file system']))
+        for mount in tasks:
+            self._wait_mount(mount.id)
+
+    def _wait_mount(self, tid):
+        try:
+            TaskManager.wait(self._gateway, tid)
+        except TaskManager.TaskError:
+            logging.getLogger().debug('Failed mounting volume. %s', {'tid': tid})

--- a/cterasdk/edge/whoami.py
+++ b/cterasdk/edge/whoami.py
@@ -1,3 +1,0 @@
-def whoami(CTERAHost):
-    session = CTERAHost.session()
-    print(session)

--- a/cterasdk/object/Agent.py
+++ b/cterasdk/object/Agent.py
@@ -18,6 +18,10 @@ class Agent(CTERAHost):
     def base_file_url(self):
         return self._api()
 
+    @property
+    def _login_object(self):
+        raise NotImplementedError("Currently login is not supported for Agent")
+
     def _is_authenticated(self, function, *args, **kwargs):
         return True
 

--- a/cterasdk/object/Agent.py
+++ b/cterasdk/object/Agent.py
@@ -6,9 +6,20 @@ class Agent(CTERAHost):
     def __init__(self, host, port=80, https=False, Portal=None):
         super().__init__(host, port, https)
         self._remote_access = False
-        if Portal is not None:
-            self._Portal = Portal
+        self._Portal = Portal
+        if self._Portal is not None:
             self._ctera_client = Portal._ctera_client
+
+    @property
+    def base_api_url(self):
+        return self._api()
+
+    @property
+    def base_file_url(self):
+        return self._api()
+
+    def _is_authenticated(self, function, *args, **kwargs):
+        return True
 
     def test(self):
         '''
@@ -19,41 +30,14 @@ class Agent(CTERAHost):
         NetworkHost.test_conn(self)
         self.get('/nosession/logininfo')
 
-    def get(self, path, params=None):
-        return CTERAHost.get(self, self._api(), path, params if params else {})
-
-    def show(self, path):
-        CTERAHost.show(self, self._api(), path)
-
-    def get_multi(self, paths):
-        return CTERAHost.get_multi(self, self._api(), paths)
-
-    def show_multi(self, paths):
-        CTERAHost.show_multi(self, self._api(), paths)
-
-    def put(self, path, value):
-        return CTERAHost.put(self, self._api(), path, value)
-
-    def post(self, path, value):
-        return CTERAHost.post(self, self._api(), path, value)
-
-    def execute(self, path, name, param=None):
-        return CTERAHost.execute(self, self._api(), path, name, param)
-
-    def add(self, path, param):
-        return CTERAHost.add(self, self._api(), path, param)
-
-    def delete(self, path):
-        return CTERAHost.delete(self, self._api(), path)
-
     def _api(self):
         if self._remote_access:
             return self._Portal.baseurl + '/devices/' + self._Portal.device_name + '/admingui/api'
 
-        if hasattr(self, '_Portal') and self._Portal is not None:
+        if self._Portal is not None:
             return self._Portal.baseurl + '/devicecmdnew/' + self._Portal.tenant_name + '/' + self._Portal.device_name + '/'
 
         return self._baseurl() + '/admingui/api'
 
     def _baseurl(self):
-        return NetworkHost.baseurl(self)
+        return self.baseurl()

--- a/cterasdk/object/Gateway.py
+++ b/cterasdk/object/Gateway.py
@@ -12,12 +12,10 @@ from ..edge import cli
 from ..edge import config
 from ..edge import directoryservice
 from ..edge import drive
-from ..edge import enum
 from ..edge import ftp
 from ..edge import groups
 from ..edge import licenses
 from ..edge import login
-from ..edge import whoami
 from ..edge import logs
 from ..edge import mail
 from ..edge import network
@@ -34,7 +32,7 @@ from ..edge import support
 from ..edge import sync
 from ..edge import syslog
 from ..edge import telnet
-from ..edge import timezone as edge_timezone
+from ..edge import timezone
 from ..edge import users
 from ..edge import volumes
 from ..edge import files
@@ -42,7 +40,7 @@ from ..edge import remote
 from ..edge import uri
 
 
-class Gateway(CTERAHost):  # pylint: disable=too-many-public-methods
+class Gateway(CTERAHost):  # pylint: disable=too-many-instance-attributes
 
     def __init__(self, host, port=80, https=False, Portal=None):
         super().__init__(host, port, https)
@@ -53,53 +51,97 @@ class Gateway(CTERAHost):  # pylint: disable=too-many-public-methods
             session.start_remote_session(self, Portal)
         else:
             session.inactive_session(self)
+        self.config = config.Config(self)
+        self.network = network.Network(self)
+        self.licenses = licenses.Licenses(self)
+        self.services = services.Services(self)
+        self.directoryservice = directoryservice.DirectoryService(self)
+        self.telnet = telnet.Telnet(self)
+        self.syslog = syslog.Syslog(self)
+        self.audit = audit.Audit(self)
+        self.mail = mail.Mail(self)
+        self.backup = backup.Backup(self)
+        self.sync = sync.Sync(self)
+        self.cache = cache.Cache(self)
+        self.power = power.Power(self)
+        self.users = users.Users(self)
+        self.groups = groups.Groups(self)
+        self.drive = drive.Drive(self)
+        self.volumes = volumes.Volumes(self)
+        self.array = array.Array(self)
+        self.shares = shares.Shares(self)
+        self.smb = smb.SMB(self)
+        self.aio = aio.AIO(self)
+        self.ftp = ftp.FTP(self)
+        self.afp = afp.AFP(self)
+        self.nfs = nfs.NFS(self)
+        self.rsync = rsync.RSync(self)
+        self.timezone = timezone.Timezone(self)
+        self.logs = logs.Logs(self)
+        self.ntp = ntp.NTP(self)
+        self.shell = shell.Shell(self)
+        self.cli = cli.CLI(self)
+        self.support = support.Support(self)
+        self.login = login.Login(self)
+        self.files = files.FileBrowser(self)
+
+    @property
+    def base_api_url(self):
+        return uri.api(self)
+
+    @property
+    def base_file_url(self):
+        return uri.files(self)
+
+    @property
+    def _omit_fields(self):
+        return super()._omit_fields + [
+            'config',
+            'network',
+            'licenses',
+            'services',
+            'directoryservice',
+            'telnet',
+            'syslog',
+            'audit',
+            'mail',
+            'backup',
+            'sync',
+            'cache',
+            'power',
+            'users',
+            'groups',
+            'drive',
+            'volumes',
+            'array',
+            'shares',
+            'smb',
+            'aio',
+            'ftp',
+            'afp',
+            'nfs',
+            'rsync',
+            'timezone',
+            'logs',
+            'ntp',
+            'shell',
+            'cli',
+            'support',
+            'login',
+            'files'
+            ]
+
+    def _is_authenticated(self, function, *args, **kwargs):
+        def is_nosession(path):
+            return function.__name__ == 'get' and path.startswith('/nosession')
+        current_session = self.session()
+        return current_session.authenticated() or is_nosession(args[0])
 
     def test(self):
         return connection.test(self)
 
-    def login(self, username, password):
-        login.login(self, username, password)
-
-    @decorator.authenticated
-    def logout(self):
-        login.logout(self)
-
-    def whoami(self):
-        whoami.whoami(self)
-
     def remote_access(self):
         remote.remote_access(self, self._Portal)
-
-    @decorator.authenticated
-    def get(self, path, params=None):
-        return super().get(self._api(), path, params if params else {})
-
-    @decorator.authenticated
-    def show(self, path):
-        super().show(self._api(), path)
-
-    @decorator.authenticated
-    def get_multi(self, paths):
-        return super().get_multi(self._api(), '', paths)
-
-    @decorator.authenticated
-    def show_multi(self, paths):
-        super().show_multi(self._api(), paths)
-
-    @decorator.authenticated
-    def put(self, path, value):
-        return super().put(self._api(), path, value)
-
-    @decorator.authenticated
-    def post(self, path, value):
-        return super().post(self._api(), path, value)
-
-    def form_data(self, path, form_data):
-        return super().form_data(self._api(), path, form_data)
-
-    @decorator.authenticated
-    def execute(self, path, name, param=None):
-        return super().execute(self._api(), path, name, param)
 
     @decorator.authenticated
     def query(self, path, key, value):
@@ -110,296 +152,8 @@ class Gateway(CTERAHost):  # pylint: disable=too-many-public-methods
         query.show(self, path, key, value)
 
     @decorator.authenticated
-    def add(self, path, param):
-        return super().add(self._api(), path, param)
-
-    @decorator.authenticated
-    def delete(self, path):
-        return super().delete(self._api(), path)
-
-    @decorator.authenticated
     def rm(self, path):
-        return super().delete(self._files(), path)
-
-    def location(self):
-        return config.get_location(self)
-
-    def set_location(self, location):
-        config.set_location(self, location)
-
-    def hostname(self):
-        return config.get_hostname(self)
-
-    def set_hostname(self, hostname):
-        config.set_hostname(self, hostname)
-
-    def set_static_ipaddr(self, address, subnet, gateway, DNSServer1, DNSServer2=None):
-        network.set_static_ipaddr(self, address, subnet, gateway, DNSServer1, DNSServer2)
-
-    def set_static_nameserver(self, DNSServer1, DNSServer2=None):
-        network.set_static_nameserver(self, DNSServer1, DNSServer2)
-
-    def enable_dhcp(self):
-        network.enable_dhcp(self)
-
-    def tcp_connect(self, address, port):
-
-        return network.tcp_connect(self, address, port)
-
-    def connect(self, server, user, password, ctera_license=enum.License.EV16):
-        services.connect(self, server, user, password, ctera_license)
-
-    def activate(self, server, user, code, ctera_license=enum.License.EV16):
-        services.activate(self, server, user, code, ctera_license)
-
-    def apply_license(self, ctera_license):
-        licenses.apply(self, ctera_license)
-
-    def reconnect(self):
-        services.reconnect(self)
-
-    def disconnect(self):
-        services.disconnect(self)
-
-    def enable_sso(self):
-        services.enable_sso(self)
-
-    def domains(self):
-        return directoryservice.domains(self)
-
-    def advanced_mapping(self, domain, start, end):
-        directoryservice.advanced_mapping(self, domain, start, end)
-
-    def directory_services_connect(self, domain, username, password, ou=None):
-        directoryservice.connect(self, domain, username, password, ou)
-
-    def directory_services_disconnect(self):
-        directoryservice.disconnect(self)
-
-    def enable_telnet(self, code):
-        telnet.enable(self, code)
-
-    def disable_telnet(self):
-        telnet.disable(self)
-
-    def enable_syslog(self, server, port=514, proto=enum.IPProtocol.UDP, minSeverity=enum.Severity.INFO):
-        syslog.enable(self, server, port, proto, minSeverity)
-
-    def disable_syslog(self):
-        syslog.disable(self)
-
-    def enable_audit_logs(
-                self,
-                path,
-                auditEvents=None,
-                logKeepPeriod=30,
-                maxLogKBSize=102400,
-                maxRotateTime=1440,
-                includeAuditLogTag=True,
-                humanReadableAuditLog=False
-                ):
-        defaultAuditEvents = [
-            enum.AuditEvents.CreateFilesWriteData,
-            enum.AuditEvents.CreateFoldersAppendData,
-            enum.AuditEvents.WriteExtendedAttributes,
-            enum.AuditEvents.DeleteSubfoldersAndFiles,
-            enum.AuditEvents.WriteAttributes,
-            enum.AuditEvents.Delete,
-            enum.AuditEvents.ChangePermissions,
-            enum.AuditEvents.ChangeOwner
-        ]
-        auditEvents = auditEvents or defaultAuditEvents
-        audit.enable(self, path, auditEvents, logKeepPeriod, maxLogKBSize, maxRotateTime, includeAuditLogTag, humanReadableAuditLog)
-
-    def disable_audit_logs(self):
-        audit.disable(self)
-
-    def enable_mail_server(self, SMTPServer, port=25, username=None, password=None, useTLS=True):
-        mail.enable(self, SMTPServer, port, username, password, useTLS)
-
-    def disable_mail_server(self):
-        mail.disable(self)
-
-    def configure_backup(self, passphrase=None):
-        backup.configure_backup(self, passphrase)
-
-    def start_backup(self):
-        backup.start(self)
-
-    def suspend_backup(self):
-        backup.suspend(self)
-
-    def unsuspend_backup(self):
-        backup.unsuspend(self)
-
-    def suspend_sync(self):
-        sync.suspend(self)
-
-    def unsuspend_sync(self):
-        sync.unsuspend(self)
-
-    def refresh_cloud_folders(self):
-        sync.refresh(self)
-
-    def enable_caching(self):
-        cache.enable(self)
-
-    def disable_caching(self):
-        cache.disable(self)
-
-    def force_eviction(self):
-        cache.force_eviction(self)
-
-    def reboot(self, wait=False):
-        power.reboot(self, wait)
-
-    def shutdown(self):
-        power.shutdown(self)
-
-    def reset(self, wait=False):
-        power.reset(self, wait)
-
-    def add_user(self, username, password, fullName=None, email=None, uid=None):
-        users.add(self, username, password, fullName, email, uid)
-
-    def add_first_user(self, username, password, email=''):
-        users.add_first_user(self, username, password, email)
-
-    def delete_user(self, username):
-        users.delete(self, username)
-
-    def add_members(self, group, members):
-        groups.add_members(self, group, members)
-
-    def remove_members(self, group, members):
-        groups.remove_members(self, group, members)
-
-    def format_drive(self, name):
-        drive.format_drive(self, name)
-
-    def format_all_drives(self):
-        drive.format_all(self)
-
-    def add_volume(self, name, size=None, fileSystemType='xfs', device=None, passphrase=None):
-        volumes.add(self, name, size, fileSystemType, device, passphrase)
-
-    def delete_volume(self, name):
-        volumes.delete(self, name)
-
-    def delete_all_volumes(self):
-        volumes.delete_all(self)
-
-    def add_array(self, name, level, members):
-        array.add(self, name, level, members)
-
-    def delete_array(self, name):
-        array.delete(self, name)
-
-    def delete_all_arrays(self, _name, _level, _members):
-        array.delete_all(self)
-
-    def add_share(
-                self,
-                name,
-                directory,
-                acl=None,
-                access=enum.Acl.WindowsNT,
-                csc=enum.ClientSideCaching.Manual,
-                dirPermissions=777,
-                comment=None,
-                exportToAFP=False,
-                exportToFTP=False,
-                exportToNFS=False,
-                exportToPCAgent=False,
-                exportToRSync=False,
-                indexed=False
-                ):  # pylint: disable=too-many-arguments
-        shares.add(
-            self,
-            name,
-            directory,
-            acl if acl else [],
-            access,
-            csc,
-            dirPermissions,
-            comment,
-            exportToAFP,
-            exportToFTP,
-            exportToNFS,
-            exportToPCAgent,
-            exportToRSync,
-            indexed
-        )
-
-    def add_share_acl(self, name, acl):
-        shares.add_acl(self, name, acl)
-
-    def remove_share_acl(self, name, acl):
-        shares.remove_acl(self, name, acl)
-
-    def delete_share(self, name):
-        shares.delete(self, name)
-
-    def enable_smb(self):
-        smb.enable(self)
-
-    def set_packet_signing(self, mode):
-        smb.set_packet_signing(self, mode)
-
-    def enable_abe(self):
-        smb.enable_abe(self)
-
-    def disable_abe(self):
-        smb.disable_abe(self)
-
-    def disable_smb(self):
-        smb.disable(self)
-
-    def enable_aio(self):
-        aio.enable(self)
-
-    def disable_aio(self):
-        aio.disable(self)
-
-    def disable_ftp(self):
-        ftp.disable(self)
-
-    def disable_afp(self):
-        afp.disable(self)
-
-    def disable_nfs(self):
-        nfs.disable(self)
-
-    def disable_rsync(self):
-        rsync.disable(self)
-
-    def set_timezone(self, timezone):
-        edge_timezone.set_timezone(self, timezone)
-
-    def enable_ntp(self, servers=None):
-        ntp.enable(self, servers if servers else [])
-
-    def disable_ntp(self):
-        ntp.disable(self)
-
-    def logs(self, topic, include=None, minSeverity=enum.Severity.INFO):
-        include = include or ['severity', 'time', 'msg', 'more']
-        return logs.logs(self, topic, include, minSeverity)
-
-    def run_shell_command(self, shell_command):
-        return shell.run_shell_command(self, shell_command)
-
-    def run_cli_command(self, cli_command):
-        return cli.run_cli_command(self, cli_command)
-
-    def set_debug_level(self, *levels):
-        return support.set_debug_level(self, *levels)
-
-    def get_support_report(self):
-        return support.get_support_report(self)
-
-    def files(self):
-        return files.FileBrowser(self)
+        return super().delete(path, use_file_url=True)
 
     def _api(self):
         return uri.api(self)

--- a/cterasdk/object/Gateway.py
+++ b/cterasdk/object/Gateway.py
@@ -82,7 +82,6 @@ class Gateway(CTERAHost):  # pylint: disable=too-many-instance-attributes
         self.shell = shell.Shell(self)
         self.cli = cli.CLI(self)
         self.support = support.Support(self)
-        self.login = login.Login(self)
         self.files = files.FileBrowser(self)
 
     @property
@@ -127,9 +126,12 @@ class Gateway(CTERAHost):  # pylint: disable=too-many-instance-attributes
             'shell',
             'cli',
             'support',
-            'login',
             'files'
             ]
+
+    @property
+    def _login_object(self):
+        return login.Login(self)
 
     def _is_authenticated(self, function, *args, **kwargs):
         def is_nosession(path):

--- a/cterasdk/object/Portal.py
+++ b/cterasdk/object/Portal.py
@@ -1,10 +1,10 @@
-from ..client import NetworkHost, CTERAHost
+import urllib.parse
+
+from ..client import CTERAHost, authenticated
 from ..core import connection
 from ..core import activation
 from ..core import directoryservice
-from ..core import enum
 from ..core import login
-from ..core import whoami
 from ..core import query
 from ..core import logs
 from ..core import portals
@@ -15,183 +15,126 @@ from ..core import users
 from ..core import cloudfs
 from ..core import zones
 from ..core import files
-from ..core import decorator
 
 
-class Portal(CTERAHost):  # pylint: disable=too-many-public-methods
+class Portal(CTERAHost):
 
     def __init__(self, host, port, https):
         super().__init__(host, port, https)
         session.inactive_session(self)
+        self.login = login.Login(self)
+        self.users = users.Users(self)
+        self.devices = devices.Devices(self)
+        self.directoryservice = directoryservice.DirectoryService(self)
+        self.zones = zones.Zones(self)
+        self.cloudfs = cloudfs.CloudFS(self)
+        self.activation = activation.Activation(self)
+        self.files = files.FileBrowser(self, self.file_browser_base_path)
+        self.logs = logs.Logs(self)
+
+    @property
+    def base_api_url(self):
+        raise NotImplementedError("Implementing class must implement the base_api_url property")
+
+    @property
+    def context(self):
+        raise NotImplementedError("Implementing class must implement the context property")
+
+    @property
+    def file_browser_base_path(self):
+        raise NotImplementedError("Implementing class must implement the file_browser_base_path property")
+
+    @property
+    def _omit_fields(self):
+        return super()._omit_fields + [
+            'login',
+            'users',
+            'devices',
+            'directoryservice',
+            'zones',
+            'cloudfs',
+            'activation',
+            'files',
+            'logs',
+        ]
+
+    def _is_authenticated(self, function, *args, **kwargs):
+        current_session = self.session()
+        return current_session.authenticated() or current_session.initializing()
 
     def test(self):
         connection.test(self)
-        return CTERAHost.get(self, self._baseurl(), '/public/publicInfo', params={})
+        return self.get('/public/publicInfo', params={})
 
-    def login(self, username, password):
-        login.login(self, username, password)
-
-    @decorator.authenticated
-    def logout(self):
-        login.logout(self)
-
-    def whoami(self):
-        whoami.whoami(self)
-
-    @decorator.authenticated
-    def get(self, path, params=None):
-        return super().get(self._api(), path, params if params else {})
-
-    @decorator.authenticated
-    def show(self, path):
-        super().show(self._api(), path)
-
-    @decorator.authenticated
-    def get_multi(self, path, paths):
-        return super().get_multi(self._api(), path, paths)
-
-    @decorator.authenticated
-    def show_multi(self, paths):
-        super().show_multi(self._api(), paths)
-
-    @decorator.update_current_tenant
-    @decorator.authenticated
-    def put(self, path, value):
-        return super().put(self._api(), path, value)
-
-    def form_data(self, path, form_data):
-        return super().form_data(self._api(), path, form_data)
-
-    @decorator.authenticated
-    def execute(self, path, name, param=None):
-        return super().execute(self._api(), path, name, param)
-
-    @decorator.authenticated
+    @authenticated
     def query(self, path, param):
         return query.query(self, path, param)
 
-    @decorator.authenticated
+    @authenticated
     def show_query(self, path, param):
         return query.show(self, path, param)
 
-    @decorator.authenticated
-    def add(self, path, param):
-        return super().add(self._api(), path, param)
-
     def iterator(self, path, param):
         return query.iterator(self, path, param)
-
-    def local_users(self, include=None):
-        return users.local_users(self, include if include else [])
-
-    def add_user(self, username, email, first_name, last_name, password, role=enum.Role.EndUser, company=None, comment=None):
-        return users.add(self, username, email, first_name, last_name, password, role, company, comment)
-
-    def delete_user(self, username):
-        return users.delete(self, username)
-
-    def domains(self):
-        return self.get('/domains')
-
-    def domain_users(self, domain, include=None):
-        return users.domain_users(self, domain, include if include else [])
-
-    def fetch(self, tuples):
-        return directoryservice.fetch(self, tuples)
-
-    def device(self, name, include=None):
-        return devices.device(self, name, include if include else [])
-
-    def filers(self, include=None, allPortals=False, deviceTypes=None):
-        return devices.filers(self, include if include else [], allPortals, deviceTypes if deviceTypes else [])
-
-    def agents(self, include=None, allPortals=False):
-        return devices.agents(self, include if include else [], allPortals)
-
-    def server_agents(self, include=None, allPortals=False):
-        return devices.servers(self, include if include else [], allPortals)
-
-    def desktop_agents(self, include=None, allPortals=False):
-        return devices.desktops(self, include if include else [], allPortals)
-
-    def devices_by_name(self, names, include=None):
-        return devices.by_name(self, include if include else [], names)
-
-    def devices(self, include=None, allPortals=False, filters=None):
-        return devices.devices(self, include if include else [], allPortals, filters if filters else [])
-
-    def generate_code(self, username, tenant=None):
-        return activation.generate_code(self, username, tenant)
-
-    def cloudfs(self):
-        return cloudfs.CloudFS(self)
-
-    def zones(self):
-        return zones.Zones(self)
-
-    def files(self):
-        return files.FileBrowser(self)
-
-    def logs(self, topic=enum.LogTopic.System, minSeverity=enum.Severity.INFO, originType=enum.OriginType.Portal, before=None, after=None):
-        return logs.logs(self, topic, minSeverity, originType, before, after)
-
-    def _api(self):
-        return self._baseurl() + '/api'
-
-    def _baseurl(self):
-        raise NotImplementedError("Subclass must implement the _baseurl method")
 
 
 class GlobalAdmin(Portal):
 
     def __init__(self, host, port=443, https=True):
         super().__init__(host, port, https)
+        self.portals = portals.Portals(self)
+        self.servers = servers.Servers(self)
+        self._base_api_url = None
+        self._base_file_url = None
 
-    def browse_tenant(self, tenant_name):
-        portals.browse(self, tenant_name)
+    @property
+    def base_api_url(self):
+        if self._base_api_url is None:
+            self._base_api_url = urllib.parse.urljoin(self.baseurl(), 'admin/api')
+        return self._base_api_url
 
-    def browse_global_admin(self):
-        self.browse_tenant('')
+    @property
+    def base_file_url(self):
+        if self._base_file_url is None:
+            pass
+        return self._base_file_url
 
-    def servers(self, include=None):
-        return servers.servers(self, include if include else [])
+    @property
+    def _omit_fields(self):
+        return super()._omit_fields + ['portals', 'servers']
 
-    def tenants(self, include_deleted=False):
-        return portals.portals(self, include_deleted)
-
-    def add_tenant(self, name, display_name=None, billing_id=None, company=None):
-        return portals.add(self, name, display_name, billing_id, company)
-
-    def delete_tenant(self, name):
-        return portals.delete(self, name)
-
-    def undelete_tenant(self, name):
-        return portals.undelete(self, name)
-
-    @staticmethod
-    def _files():
-        return '/admin/webdav/Users'
-
-    def _baseurl(self):
-        return NetworkHost.baseurl(self) + '/' + self._context()
-
-    @staticmethod
-    def _context():
+    @property
+    def context(self):
         return 'admin'
+
+    @property
+    def file_browser_base_path(self):
+        return '/admin/webdav/Users'
 
 
 class ServicesPortal(Portal):
 
     def __init__(self, host, port=443, https=True):
         super().__init__(host, port, https)
+        self._base_api_url = None
+        self._base_file_url = None
 
-    @staticmethod
-    def _files():
-        return '/ServicesPortal/webdav'
+    @property
+    def base_api_url(self):
+        if self._base_api_url is None:
+            self._base_api_url = urllib.parse.urljoin(self.baseurl(), 'ServicesPortal/api')
+        return self._base_api_url
 
-    def _baseurl(self):
-        return NetworkHost.baseurl(self) + '/' + self._context()
+    @property
+    def base_file_url(self):
+        if self._base_file_url is None:
+            pass
+        return self._base_file_url
 
-    @staticmethod
-    def _context():
+    @property
+    def context(self):
         return 'ServicesPortal'
+
+    @property
+    def file_browser_base_path(self):
+        return '/ServicesPortal/webdav'

--- a/cterasdk/object/Portal.py
+++ b/cterasdk/object/Portal.py
@@ -1,6 +1,7 @@
 from ..client import CTERAHost, authenticated
 from ..core import connection
 from ..core import activation
+from ..core import decorator
 from ..core import directoryservice
 from ..core import login
 from ..core import query
@@ -67,6 +68,10 @@ class Portal(CTERAHost):
     def test(self):
         connection.test(self)
         return self.get('/public/publicInfo', params={})
+
+    @decorator.update_current_tenant
+    def put(self, path, value, use_file_url=False):
+        return super().put(path, value, use_file_url=use_file_url)
 
     @authenticated
     def query(self, path, param):

--- a/cterasdk/object/Portal.py
+++ b/cterasdk/object/Portal.py
@@ -1,5 +1,3 @@
-import urllib.parse
-
 from ..client import CTERAHost, authenticated
 from ..core import connection
 from ..core import activation
@@ -34,7 +32,11 @@ class Portal(CTERAHost):
 
     @property
     def base_api_url(self):
-        raise NotImplementedError("Implementing class must implement the base_api_url property")
+        return self.base_portal_url + '/api'
+
+    @property
+    def base_portal_url(self):
+        raise NotImplementedError("Implementing class must implement the base_url property")
 
     @property
     def context(self):
@@ -84,20 +86,14 @@ class GlobalAdmin(Portal):
         super().__init__(host, port, https)
         self.portals = portals.Portals(self)
         self.servers = servers.Servers(self)
-        self._base_api_url = None
-        self._base_file_url = None
 
     @property
-    def base_api_url(self):
-        if self._base_api_url is None:
-            self._base_api_url = urllib.parse.urljoin(self.baseurl(), 'admin/api')
-        return self._base_api_url
+    def base_portal_url(self):
+        return self.baseurl() + '/admin'
 
     @property
     def base_file_url(self):
-        if self._base_file_url is None:
-            pass
-        return self._base_file_url
+        return None
 
     @property
     def _omit_fields(self):
@@ -116,20 +112,14 @@ class ServicesPortal(Portal):
 
     def __init__(self, host, port=443, https=True):
         super().__init__(host, port, https)
-        self._base_api_url = None
-        self._base_file_url = None
 
     @property
-    def base_api_url(self):
-        if self._base_api_url is None:
-            self._base_api_url = urllib.parse.urljoin(self.baseurl(), 'ServicesPortal/api')
-        return self._base_api_url
+    def base_portal_url(self):
+        return self.baseurl() + '/ServicesPortal'
 
     @property
     def base_file_url(self):
-        if self._base_file_url is None:
-            pass
-        return self._base_file_url
+        return None
 
     @property
     def context(self):

--- a/cterasdk/object/Portal.py
+++ b/cterasdk/object/Portal.py
@@ -21,7 +21,6 @@ class Portal(CTERAHost):
     def __init__(self, host, port, https):
         super().__init__(host, port, https)
         session.inactive_session(self)
-        self.login = login.Login(self)
         self.users = users.Users(self)
         self.devices = devices.Devices(self)
         self.directoryservice = directoryservice.DirectoryService(self)
@@ -50,7 +49,6 @@ class Portal(CTERAHost):
     @property
     def _omit_fields(self):
         return super()._omit_fields + [
-            'login',
             'users',
             'devices',
             'directoryservice',
@@ -60,6 +58,10 @@ class Portal(CTERAHost):
             'files',
             'logs',
         ]
+
+    @property
+    def _login_object(self):
+        return login.Login(self)
 
     def _is_authenticated(self, function, *args, **kwargs):
         current_session = self.session()


### PR DESCRIPTION
CTERAHost
---------
Check whether the session is active before calling HTTP calls
Define abstract method for child specific authenticated check
Define abstract propertiers for base_api_url and base_file_url
Allow the caller of the HTTP methods to decide whether to use the base_api_url or the base_file_url
Implement whoami at this level

edge/core modules
-----------------
Put each module in edge and code into its own class
Remove unused whoami modules
Adjust the calls to the HTTP methods based on the changes in the CTERAHost class

Portal/Gateway/Agent
--------------------
Hold instances of the module classes, allowing the users to access them directly
Remove all wrapper methods
Remove the HTTP wrapper methods

PyLint
------
Object.py Disable too-many-instance-attributes error