### PR TITLE
Saimon/add shares set acl

### DIFF
--- a/cterasdk/edge/shares.py
+++ b/cterasdk/edge/shares.py
@@ -49,7 +49,7 @@ class Shares(BaseCommand):
         param.acl = []
         for entry in acl:
             if len(entry) != 3:
-                raise InputError('Invalid input', repr(entry), '[("type", "name", "perm"), ...]')
+                Shares._invalid_ace(entry)
             Shares._add_share_acl_rule(param.acl, entry[0], entry[1], entry[2])
 
         try:
@@ -58,6 +58,14 @@ class Shares(BaseCommand):
         except Exception as error:
             logging.getLogger().error("Share creation failed.")
             raise CTERAException('Share creation failed', error)
+            
+    def set_acl(self, name, acl):
+        param = []
+        for entry in acl:
+            if len(entry) != 3:
+                Shares._invalid_ace(entry)
+            Shares._add_share_acl_rule(param, entry[0], entry[1], entry[2])
+        self._gateway.put('/config/fileservices/share/' + name + '/acl', param)
 
     def add_acl(self, name, acl):
         current_acl = self._gateway.get('/config/fileservices/share/' + name + '/acl')
@@ -66,7 +74,7 @@ class Shares(BaseCommand):
         for entry in acl:
             temp_acl = []
             if len(entry) != 3:
-                raise InputError('Invalid input', repr(entry), '[("type", "name", "perm"), ...]')
+                Shares._invalid_ace(entry)
             Shares._add_share_acl_rule(temp_acl, entry[0], entry[1], entry[2])
             entry_key = entry[0] + '#' + entry[1]
             new_acl_dict[entry_key] = temp_acl[0]
@@ -163,3 +171,7 @@ class Shares(BaseCommand):
         acls.append(ace)
 
         return acls
+    
+    @staticmethod
+    def _invalid_ace(entry):
+        raise InputError('Invalid input', repr(entry), '[("type", "name", "perm"), ...]')

--- a/cterasdk/edge/shares.py
+++ b/cterasdk/edge/shares.py
@@ -60,6 +60,16 @@ class Shares(BaseCommand):
             raise CTERAException('Share creation failed', error)
             
     def set_acl(self, name, acl):
+        """
+        Set a network share's access control entries.
+        
+        :param name: the name of a network share
+        :param acl: a list of 3-tuple access control entries
+        :type name: str
+        :type acl: list[tuple(str, str, str)]
+        
+        .. warning: this method will override the existing access control entries
+        """
         param = []
         for entry in acl:
             if len(entry) != 3:


### PR DESCRIPTION
1. Added the ability to set (override) network share ACL's
2. Added _invalid_ace() method to raise ACL format error and updated the respective methods to use it