### PR TITLE
Add unit tests for converting objects from and to XML and JSON

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -141,7 +141,8 @@ disable=print-statement,
         comprehension-escape,
         missing-docstring,
         invalid-name,
-        duplicate-code
+        duplicate-code,
+        no-member
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/tests/ut/base_convert.py
+++ b/tests/ut/base_convert.py
@@ -1,0 +1,35 @@
+from cterasdk import fromxmlstr, toxmlstr, tojsonstr
+from tests.ut import base
+
+
+class TestJSON(base.BaseTest):
+
+    @staticmethod
+    def _tojsonstr(value):
+        return tojsonstr(value, False)
+
+
+class TestXML(base.BaseTest):
+
+    @staticmethod
+    def _format_list_of_values(values):
+        list_of_values = ''
+        if values:
+            for value in values:
+                list_of_values = list_of_values + TestXML._format_value(value)
+            return '<list>%s</list>' % list_of_values
+        return '<list />'
+
+    @staticmethod
+    def _format_value(value):
+        if isinstance(value, bool):
+            value = str(value).lower()
+        return '<val>%s</val>' % value
+
+    @staticmethod
+    def _fromxmlstr(value):
+        return fromxmlstr(value.encode('utf-8'))
+
+    @staticmethod
+    def _toxmlstr(value):
+        return toxmlstr(value).decode('utf-8')

--- a/tests/ut/test_convert_format_json.py
+++ b/tests/ut/test_convert_format_json.py
@@ -1,0 +1,49 @@
+from cterasdk import Object
+from tests.ut import base_convert
+
+
+class TestFormatObjectJSON(base_convert.TestJSON):
+
+    def test_null(self):
+        o = Object()
+        o.company = None
+        self.assertEqual(base_convert.TestJSON._tojsonstr(o), '{"company": null}')
+
+    def test_int(self):
+        o = Object()
+        o.uid = 2156
+        self.assertEqual(base_convert.TestJSON._tojsonstr(o), '{"uid": 2156}')
+
+    def test_str(self):
+        o = Object()
+        o.name = "alice"
+        self.assertEqual(base_convert.TestJSON._tojsonstr(o), '{"name": "alice"}')
+
+    def test_bool_true(self):
+        o = Object()
+        o.active = True
+        self.assertEqual(base_convert.TestJSON._tojsonstr(o), '{"active": true}')
+
+    def test_bool_false(self):
+        o = Object()
+        o.active = False
+        self.assertEqual(base_convert.TestJSON._tojsonstr(o), '{"active": false}')
+
+    def test_list(self):
+        o = Object()
+        o.drives = ['SATA-' + str(i) for i in range(1, 4)]
+        self.assertEqual(base_convert.TestJSON._tojsonstr(o), '{"drives": ["SATA-1", "SATA-2", "SATA-3"]}')
+
+    def test_object(self):
+        o = Object()
+        o.config = Object()
+        o.config.device = Object()
+        o.config.device.name = "CTERA"
+        o.config.device.uptime = "P0Y0M0DT0H0M24S"
+        o.config.device.runningFirmware = "6.0.589.0"
+        device_config = '{"config": ' \
+            '{"device": ' \
+            '{"name": "CTERA", "uptime": "P0Y0M0DT0H0M24S", "runningFirmware": "6.0.589.0"}' \
+            '}' \
+            '}'
+        self.assertEqual(base_convert.TestJSON._tojsonstr(o), device_config)

--- a/tests/ut/test_convert_format_xml.py
+++ b/tests/ut/test_convert_format_xml.py
@@ -1,0 +1,65 @@
+from cterasdk import Object
+from tests.ut import base_convert
+
+
+class TestFormatObjectXML(base_convert.TestXML):
+
+    def test_named_tuple(self):
+        o = Object()
+        o.name = "alice"
+        o.email = "alice.wonderland@microsoft.com"
+        o.firstName = "Alice"
+        o.lastName = "Wonderland"
+        o.company = "Microsoft Corporation"
+        o.showTutorial = True
+        o.uid = 2156
+        o.password = None
+        user_object = '<obj>' \
+            '<att id="name"><val>alice</val></att>' \
+            '<att id="email"><val>alice.wonderland@microsoft.com</val></att>' \
+            '<att id="firstName"><val>Alice</val></att>' \
+            '<att id="lastName"><val>Wonderland</val></att>' \
+            '<att id="company"><val>Microsoft Corporation</val></att>' \
+            '<att id="showTutorial"><val>true</val></att>' \
+            '<att id="uid"><val>2156</val></att>' \
+            '<att id="password" />' \
+            '</obj>'
+        self.assertEqual(base_convert.TestXML._toxmlstr(o), user_object)
+
+
+class TestFormatListValueXML(base_convert.TestXML):
+
+    def test_list_of_int(self):
+        values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        self.assertEqual(base_convert.TestXML._toxmlstr(values), base_convert.TestXML._format_list_of_values(values))
+
+    def test_list_of_str(self):
+        values = ['SATA-' + str(i) for i in range(1, 11)]
+        self.assertEqual(base_convert.TestXML._toxmlstr(values), base_convert.TestXML._format_list_of_values(values))
+
+
+class TestFormatValueXML(base_convert.TestXML):
+
+    def test_int(self):
+        value = 1024
+        self.assertEqual(base_convert.TestXML._toxmlstr(value), base_convert.TestXML._format_value(value))
+
+    def test_str(self):
+        value = 'SATA-1'
+        self.assertEqual(base_convert.TestXML._toxmlstr(value), base_convert.TestXML._format_value(value))
+
+    def test_str_with_spaces(self):
+        value = 'The quick brown fox jumped over the lazy dog'
+        self.assertEqual(base_convert.TestXML._toxmlstr(value), base_convert.TestXML._format_value(value))
+
+    def test_true_bool(self):
+        value = True
+        self.assertEqual(base_convert.TestXML._toxmlstr(value), base_convert.TestXML._format_value(value))
+
+    def test_false_bool(self):
+        value = False
+        self.assertEqual(base_convert.TestXML._toxmlstr(value), base_convert.TestXML._format_value(value))
+
+    def test_float(self):
+        value = 0.6901
+        self.assertEqual(base_convert.TestXML._toxmlstr(value), base_convert.TestXML._format_value(value))

--- a/tests/ut/test_convert_parse_json.py
+++ b/tests/ut/test_convert_parse_json.py
@@ -1,0 +1,44 @@
+from cterasdk import fromjsonstr
+from tests.ut import base_convert
+
+
+class TestParseObjectJSON(base_convert.TestJSON):
+
+    def test_json_object(self):
+        user_object = '{' \
+            '"name": "alice", ' \
+            '"email": "alice.wonderland@microsoft.com", ' \
+            '"firstName": "Alice", ' \
+            '"lastName": "Wonderland", ' \
+            '"company": "Microsoft Corporation", ' \
+            '"showTutorial": true, ' \
+            '"uid": 2156,' \
+            '"password" : null' \
+            '}'
+        o = fromjsonstr(user_object)
+        self.assertEqual(o.name, 'alice')
+        self.assertEqual(o.email, 'alice.wonderland@microsoft.com')
+        self.assertEqual(o.firstName, 'Alice')
+        self.assertEqual(o.lastName, 'Wonderland')
+        self.assertEqual(o.company, 'Microsoft Corporation')
+        self.assertEqual(o.showTutorial, True)
+        self.assertEqual(o.uid, 2156)
+        self.assertEqual(o.password, None)
+
+    def test_json_array(self):
+        disks = '['\
+            '{"name": "SATA1", "isCtera": true, "serial": "JPW9K0N01AU4HL", "firmware": "JP4OA3EA", "logicalCapacity": 952830}, ' \
+            '{"name": "SATA2", "isCtera": false, "serial": "JPW9K0N01968XL", "firmware": "JP4OA3EA", "logicalCapacity": 952830}' \
+            ']'
+        o = fromjsonstr(disks)
+        self.assertEqual(o[0].name, 'SATA1')
+        self.assertEqual(o[0].isCtera, True)
+        self.assertEqual(o[0].serial, 'JPW9K0N01AU4HL')
+        self.assertEqual(o[0].firmware, 'JP4OA3EA')
+        self.assertEqual(o[0].logicalCapacity, 952830)
+
+        self.assertEqual(o[1].name, 'SATA2')
+        self.assertEqual(o[1].isCtera, False)
+        self.assertEqual(o[1].serial, 'JPW9K0N01968XL')
+        self.assertEqual(o[1].firmware, 'JP4OA3EA')
+        self.assertEqual(o[1].logicalCapacity, 952830)

--- a/tests/ut/test_convert_parse_xml.py
+++ b/tests/ut/test_convert_parse_xml.py
@@ -1,0 +1,116 @@
+from tests.ut import base_convert
+
+
+class TestParseObjectXML(base_convert.TestXML):
+
+    def test_named_tuple(self):
+        user_object = '<obj>' \
+            '<att id="name"><val>alice</val></att>' \
+            '<att id="email"><val>alice.wonderland@microsoft.com</val></att>' \
+            '<att id="firstName"><val>Alice</val></att>' \
+            '<att id="lastName"><val>Wonderland</val></att>' \
+            '<att id="company"><val>Microsoft Corporation</val></att>' \
+            '<att id="showTutorial"><val>true</val></att>' \
+            '<att id="uid"><val>2156</val></att>' \
+            '<att id="password" />' \
+            '</obj>'
+        o = base_convert.TestXML._fromxmlstr(user_object)
+        self.assertEqual(o.name, 'alice')
+        self.assertEqual(o.email, 'alice.wonderland@microsoft.com')
+        self.assertEqual(o.firstName, 'Alice')
+        self.assertEqual(o.lastName, 'Wonderland')
+        self.assertEqual(o.company, 'Microsoft Corporation')
+        self.assertEqual(o.showTutorial, True)
+        self.assertEqual(o.uid, 2156)
+        self.assertEqual(o.password, None)
+
+    def test_list_of_objects(self):
+        disks = '<list key="name">' \
+            '<obj class="DiskStatus" uuid="ba94e323-e988-4c3d-a353-3fc5402a8614">' \
+            '<att id="name">' \
+            '<val>SATA1</val>' \
+            '</att>' \
+            '<att id="isCtera">' \
+            '<val>true</val>' \
+            '</att>' \
+            '<att id="serial">' \
+            '<val>JPW9K0N01AU4HL</val>' \
+            '</att>' \
+            '<att id="firmware">' \
+            '<val>JP4OA3EA</val>' \
+            '</att>' \
+            '<att id="logicalCapacity">' \
+            '<val>952830</val>' \
+            '</att>' \
+            '</obj>' \
+            '<obj class="DiskStatus" uuid="3c875a08-4de9-461f-8b52-a7e3dfb1bf2d">' \
+            '<att id="name">' \
+            '<val>SATA2</val>' \
+            '</att>' \
+            '<att id="isCtera">' \
+            '<val>false</val>' \
+            '</att>' \
+            '<att id="serial">' \
+            '<val>JPW9K0N01968XL</val>' \
+            '</att>' \
+            '<att id="firmware">' \
+            '<val>JP4OA3EA</val>' \
+            '</att>' \
+            '<att id="logicalCapacity">' \
+            '<val>952830</val>' \
+            '</att>' \
+            '</obj>' \
+            '</list>'
+        o = base_convert.TestXML._fromxmlstr(disks)
+        self.assertEqual(o[0].name, 'SATA1')
+        self.assertEqual(o[0].isCtera, True)
+        self.assertEqual(o[0].serial, 'JPW9K0N01AU4HL')
+        self.assertEqual(o[0].firmware, 'JP4OA3EA')
+        self.assertEqual(o[0].logicalCapacity, 952830)
+
+        self.assertEqual(o[1].name, 'SATA2')
+        self.assertEqual(o[1].isCtera, False)
+        self.assertEqual(o[1].serial, 'JPW9K0N01968XL')
+        self.assertEqual(o[1].firmware, 'JP4OA3EA')
+        self.assertEqual(o[1].logicalCapacity, 952830)
+
+
+class TestParseListValueXML(base_convert.TestXML):
+
+    def test_list_of_int(self):
+        original_values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        formatted_values = base_convert.TestXML._format_list_of_values(original_values)
+        self.assertEqual(base_convert.TestXML._fromxmlstr(formatted_values), original_values)
+
+    def test_list_of_str(self):
+        original_values = ['SATA-' + str(i) for i in range(1, 11)]
+        formatted_values = base_convert.TestXML._format_list_of_values(original_values)
+        self.assertEqual(base_convert.TestXML._fromxmlstr(formatted_values), original_values)
+
+
+class TestParseValueXML(base_convert.TestXML):
+
+    def test_int(self):
+        original_value = 1024
+        formatted_value = base_convert.TestXML._format_value(original_value)
+        self.assertEqual(base_convert.TestXML._fromxmlstr(formatted_value), original_value)
+
+    def test_str(self):
+        original_value = 'SATA-1'
+        formatted_value = base_convert.TestXML._format_value(original_value)
+        self.assertEqual(base_convert.TestXML._fromxmlstr(formatted_value), original_value)
+
+    def test_true_bool(self):
+        original_value = True
+        formatted_value = base_convert.TestXML._format_value(original_value)
+        self.assertEqual(base_convert.TestXML._fromxmlstr(formatted_value), original_value)
+
+    def test_false_bool(self):
+        original_value = False
+        formatted_value = base_convert.TestXML._format_value(original_value)
+        self.assertEqual(base_convert.TestXML._fromxmlstr(formatted_value), original_value)
+
+    def test_float(self):
+        original_value = 0.6901
+        formatted_value = base_convert.TestXML._format_value(original_value)
+        self.assertEqual(base_convert.TestXML._fromxmlstr(formatted_value), original_value)


### PR DESCRIPTION
### XML
1. Parse primitive values (int, str, bool, float) from XML to a Python primitive
2. Parse list of primitive values (int, str) from XML to a Python list
3. Parse an object from XML to a Python named tuple object
4. Parse a list of objects from XML to a list of Python objects
5. Format primitive values (int, str, bool, float) to XML
6. Format list of primitive (int, str) values to XML
7. Format a named tuple Python object to XML

### JSON
1. Format JSON objects (null, int, str, bool, float)
2. Format JSON array
3. Parse a JSON object to a Python object
4. Parse a JSON array to a list of Python objects

Add a pylint setting to disable 'no-member' errors raised for class attributes that are set dynamically [http://pylint-messages.wikidot.com/messages:e1101]