### PR TITLE
Support creating a cloud drive folder owned by a domain user account

### DIFF
--- a/cterasdk/core/cloudfs.py
+++ b/cterasdk/core/cloudfs.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import logging
 
 from .base_command import BaseCommand
@@ -59,11 +60,13 @@ class CloudFS(BaseCommand):
 
         :param str name: Name of the new directory
         :param str group: The Folder Group to which the directory belongs
-        :param str owner: User name of the owner of the new directory
+        :param UserAccount owner: User account, the owner of the new directory
         :param bool,optional winacls: Use Windows ACLs, defaults to True
         """
+        directory, user = owner
+        baseurl = ('/users/' + user) if directory == 'local' else '/domains/' + directory + '/adUsers/' + user
 
-        owner = self._portal.get('/users/' + owner + '/baseObjectRef')
+        owner = self._portal.get(baseurl + '/baseObjectRef')
         group = self._portal.get('/foldersGroups/' + group + '/baseObjectRef')
 
         param = Object()
@@ -148,3 +151,11 @@ class CloudFS(BaseCommand):
         owner = self._portal.get('/users/' + owner + '/displayName')
         path = owner + '/' + name
         return path
+
+
+UserAccount = namedtuple('UserAccount', ('directory', 'name'))
+UserAccount.__doc__ += 'Tuple holding user account information'
+UserAccount.directory.__doc__ = 'The directory the user is located in. ' \
+    'For local users, indicate "local" as the directory name. ' \
+    'For domain users, indicate the fully qualified domain name'
+UserAccount.name.__doc__ = 'The name of the user account'

--- a/docs/source/user_guides/Portal/GlobalAdmin.rst
+++ b/docs/source/user_guides/Portal/GlobalAdmin.rst
@@ -435,7 +435,11 @@ Create a Cloud Drive Folder
 
 .. code:: python
 
-   admin.cloudfs.mkdir('DIR-001', 'FG-001', 'svc_account')
+   """Create a Cloud Drive folder, owned by a local user account 'svc_account'"""
+   admin.cloudfs.mkdir('DIR-001', 'FG-001', ('local', 'svc_account'))
+
+   """Create a Cloud Drive folder, owned by a domain user account 'wbruce'"""
+   admin.cloudfs.mkdir('DIR-001', 'FG-001', ('ctera.local', 'wbruce'))
 
    admin.cloudfs.mkdir('DIR-002', 'FG-001', 'svc_account', winacls = False) # disable Windows ACL's
 

--- a/tests/ut/test_core_cloudfs.py
+++ b/tests/ut/test_core_cloudfs.py
@@ -11,6 +11,7 @@ class TestCoreCloudFS(base_core.BaseCoreTest):
     def setUp(self):
         super().setUp()
         self._owner = 'admin'
+        self._local_user_account = cloudfs.UserAccount('local', self._owner)
         self._group = 'admin'
         self._name = 'folderGroup'
 
@@ -60,10 +61,10 @@ class TestCoreCloudFS(base_core.BaseCoreTest):
         cloudfs.CloudFS(self._global_admin).rmfg(self._name)
         self._global_admin.execute.assert_called_once_with('/foldersGroups/' + self._name, 'deleteGroup', True)
 
-    def test_mkdir_no_winacls_param(self):
+    def test_mkdir_local_owner_no_winacls_param(self):
         get_response = 'admin'
         self._init_global_admin(get_response=get_response, execute_response='Success')
-        ret = cloudfs.CloudFS(self._global_admin).mkdir(self._name, self._group, self._owner)
+        ret = cloudfs.CloudFS(self._global_admin).mkdir(self._name, self._group, self._local_user_account)
         self._global_admin.get.assert_has_calls(
             [
                 mock.call(('/users/' + self._owner + '/baseObjectRef')),
@@ -78,10 +79,10 @@ class TestCoreCloudFS(base_core.BaseCoreTest):
 
         self.assertEqual(ret, 'Success')
 
-    def test_mkdir_winacls_true(self):
+    def test_mkdir_local_owner_winacls_true(self):
         get_response = 'admin'
         self._init_global_admin(get_response=get_response, execute_response='Success')
-        ret = cloudfs.CloudFS(self._global_admin).mkdir(self._name, self._group, self._owner, True)
+        ret = cloudfs.CloudFS(self._global_admin).mkdir(self._name, self._group, self._local_user_account, True)
         self._global_admin.get.assert_has_calls(
             [
                 mock.call(('/users/' + self._owner + '/baseObjectRef')),
@@ -96,10 +97,10 @@ class TestCoreCloudFS(base_core.BaseCoreTest):
 
         self.assertEqual(ret, 'Success')
 
-    def test_mkdir_winacls_false(self):
+    def test_mkdir_local_owner_winacls_false(self):
         get_response = 'admin'
         self._init_global_admin(get_response=get_response, execute_response='Success')
-        ret = cloudfs.CloudFS(self._global_admin).mkdir(self._name, self._group, self._owner, False)
+        ret = cloudfs.CloudFS(self._global_admin).mkdir(self._name, self._group, self._local_user_account, False)
         self._global_admin.get.assert_has_calls(
             [
                 mock.call(('/users/' + self._owner + '/baseObjectRef')),
@@ -114,14 +115,14 @@ class TestCoreCloudFS(base_core.BaseCoreTest):
 
         self.assertEqual(ret, 'Success')
 
-    def test_mkdir_raise(self):
+    def test_mkdir_local_owner_raise(self):
         get_response = 'admin'
         self._init_global_admin(get_response=get_response, execute_response='Success')
         error_message = "Expected Failure"
         expected_exception = exception.CTERAException(message=error_message)
         self._global_admin.execute = mock.MagicMock(side_effect=expected_exception)
         with self.assertRaises(exception.CTERAException) as error:
-            cloudfs.CloudFS(self._global_admin).mkdir(self._name, self._group, self._owner)
+            cloudfs.CloudFS(self._global_admin).mkdir(self._name, self._group, self._local_user_account)
         self._global_admin.get.assert_has_calls(
             [
                 mock.call(('/users/' + self._owner + '/baseObjectRef')),


### PR DESCRIPTION
- Add a UserAccount named tuple accepting a directory (local or domain) and a user account.
- Adapt mkdir to lookup the Cloud Drive owner in the relevant user directory
- Renamed the mkdir tests in test_core_cloudfs to indicate the tests are for a local user account owner
- Updated the examples provided in the SDK documentation