### PR TITLE
Add unit tests for edge modules. Add RAID level enumerator

### DIFF
--- a/cterasdk/edge/array.py
+++ b/cterasdk/edge/array.py
@@ -20,7 +20,7 @@ class Array(BaseCommand):
         Add a new array
 
         :param str array_name: Name for the new array
-        :param str level:
+        :param RAIDLevel level: RAID level
         :param list(str) members: Members of the array
         """
         param = Object()

--- a/cterasdk/edge/enum.py
+++ b/cterasdk/edge/enum.py
@@ -301,3 +301,20 @@ class ServicesConnectionState:
     """
     Disconnected = "Disconnected"
     Connected = "Connected"
+
+
+class RAIDLevel:
+    """
+    RAID Levels
+
+    :ivar str JBOD: Linear concatenation
+    :ivar str RAID_0: Stripe set
+    :ivar str RAID_1: Mirror
+    :ivar str RAID_5: Distributed parity
+    :ivar str RAID_6: Dual parity
+    """
+    JBOD = "linear"
+    RAID_0 = "0"
+    RAID_1 = "1"
+    RAID_5 = "5"
+    RAID_6 = "6"

--- a/cterasdk/edge/telnet.py
+++ b/cterasdk/edge/telnet.py
@@ -10,11 +10,6 @@ class Telnet(BaseCommand):
 
     def enable(self, code):
         """ Enable Telnet """
-        status = self._gateway.get('/status/device')
-        version = status.runningFirmware
-        if version.count('.') == 2:
-            version = version + '.0'
-
         param = Object()
         param.code = code
 

--- a/tests/ut/base_edge.py
+++ b/tests/ut/base_edge.py
@@ -11,10 +11,12 @@ class BaseEdgeTest(base.BaseTest):
         self._filer = Gateway("")
 
     def _init_filer(self, get_response=None, put_response=None, post_response=None,
-                    add_response=None, execute_response=None, delete_response=None):
+                    form_data_response=None, add_response=None, execute_response=None,
+                    delete_response=None):
         self._filer.get = mock.MagicMock(return_value=get_response)
         self._filer.put = mock.MagicMock(return_value=put_response)
         self._filer.post = mock.MagicMock(return_value=post_response)
+        self._filer.form_data = mock.MagicMock(return_value=form_data_response)
         self._filer.add = mock.MagicMock(return_value=add_response)
         self._filer.execute = mock.MagicMock(return_value=execute_response)
         self._filer.delete = mock.MagicMock(return_value=delete_response)

--- a/tests/ut/test_edge_array.py
+++ b/tests/ut/test_edge_array.py
@@ -1,0 +1,83 @@
+from unittest import mock
+
+from cterasdk import exception
+from cterasdk.edge import array
+from cterasdk.edge.enum import RAIDLevel
+from cterasdk.common import Object
+from tests.ut import base_edge
+
+
+class TestEdgeArray(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._array_name = 'array'
+        self._array_level = RAIDLevel.JBOD
+        self._array_members = ['SATA-%s' % i for i in range(1, 9)]
+
+    def test_get_all_arrays(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = array.Array(self._filer).get()
+        self._filer.get.assert_called_once_with('/config/storage/arrays')
+        self.assertEqual(ret, get_response)
+
+    def test_get_array(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = array.Array(self._filer).get(self._array_name)
+        self._filer.get.assert_called_once_with('/config/storage/arrays/' + self._array_name)
+        self.assertEqual(ret, get_response)
+
+    def test_add_array_success(self):
+        add_response = 'Success'
+        self._init_filer(add_response=add_response)
+        ret = array.Array(self._filer).add(self._array_name, self._array_level, self._array_members)
+        self._filer.add.assert_called_once_with('/config/storage/arrays', mock.ANY)
+
+        expected_param = self._get_array_object()
+        actual_param = self._filer.add.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+        self.assertEqual(ret, add_response)
+
+    def test_add_array_failure(self):
+        expected_exception = exception.CTERAException()
+        self._filer.add = mock.MagicMock(side_effect=expected_exception)
+        with self.assertRaises(exception.CTERAException) as error:
+            array.Array(self._filer).add(self._array_name, self._array_level, self._array_members)
+        self.assertEqual('Storage array creation failed.', error.exception.message)
+
+    def test_delete_array_success(self):
+        delete_response = 'Success'
+        self._init_filer(delete_response=delete_response)
+        ret = array.Array(self._filer).delete(self._array_name)
+        self._filer.delete.assert_called_once_with('/config/storage/arrays/' + self._array_name)
+        self.assertEqual(ret, delete_response)
+
+    def test_delete_array_failure(self):
+        expected_exception = exception.CTERAException()
+        self._filer.delete = mock.MagicMock(side_effect=expected_exception)
+        with self.assertRaises(exception.CTERAException) as error:
+            array.Array(self._filer).delete(self._array_name)
+        self.assertEqual('Storage array deletion failed.', error.exception.message)
+
+    def test_delete_all(self):
+        self.patch_call("cterasdk.edge.array.Array.delete")
+        arrays = self._get_arrays_param()
+        self._init_filer(get_response=arrays)
+        array.Array(self._filer).delete_all()
+        self._filer.get.assert_called_once_with('/config/storage/arrays')
+
+    def _get_array_object(self):
+        array_param = Object()
+        array_param.name = self._array_name
+        array_param.level = self._array_level
+        array_param.members = self._array_members
+        return array_param
+
+    def _get_arrays_param(self):
+        array_param = Object()
+        array_param.name = self._array_name
+        arrays = [array_param]
+        return arrays

--- a/tests/ut/test_edge_backup.py
+++ b/tests/ut/test_edge_backup.py
@@ -1,0 +1,26 @@
+from cterasdk.edge import backup
+from tests.ut import base_edge
+
+
+class TestEdgeBackup(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._task_id = '137'
+        self._shared_secret = 'shared secret'
+        self._passphrase_salt = 'salt'
+
+    def test_start_backup(self):
+        self._init_filer()
+        backup.Backup(self._filer).start()
+        self._filer.execute.assert_called_once_with('/status/sync', 'start')
+
+    def test_suspend_backup(self):
+        self._init_filer()
+        backup.Backup(self._filer).suspend()
+        self._filer.execute.assert_called_once_with('/status/sync', 'pause')
+
+    def test_unsuspend_backup(self):
+        self._init_filer()
+        backup.Backup(self._filer).unsuspend()
+        self._filer.execute.assert_called_once_with('/status/sync', 'resume')

--- a/tests/ut/test_edge_cli.py
+++ b/tests/ut/test_edge_cli.py
@@ -1,0 +1,16 @@
+from cterasdk.edge import cli
+from tests.ut import base_edge
+
+
+class TestEdgeCLI(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._cli_command = 'show /config/fileservices/cifs'
+
+    def test_run_cli_command(self):
+        execute_response = 'Success'
+        self._init_filer(execute_response=execute_response)
+        ret = cli.CLI(self._filer).run_command(self._cli_command)
+        self._filer.execute.assert_called_once_with('/config/device', 'debugCmd', self._cli_command)
+        self.assertEqual(ret, execute_response)

--- a/tests/ut/test_edge_drive.py
+++ b/tests/ut/test_edge_drive.py
@@ -1,0 +1,52 @@
+from unittest import mock
+
+from cterasdk.edge import drive
+from cterasdk.common import Object
+from tests.ut import base_edge
+
+
+class TestEdgeDrive(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._drive_name = 'XVD2'
+
+    def test_get_all_drives(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = drive.Drive(self._filer).get()
+        self._filer.get.assert_called_once_with('/config/storage/disks')
+        self.assertEqual(ret, get_response)
+
+    def test_get_drive(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = drive.Drive(self._filer).get(self._drive_name)
+        self._filer.get.assert_called_once_with('/config/storage/disks/' + self._drive_name)
+        self.assertEqual(ret, get_response)
+
+    def test_format_drive(self):
+        self._init_filer()
+        drive.Drive(self._filer).format(self._drive_name)
+        self._filer.execute.assert_called_once_with('/proc/storage', 'format', mock.ANY)
+
+        expected_param = Object()
+        expected_param.name = self._drive_name
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_format_all_drives(self):
+        self._init_filer(get_response=self._get_drives_param())
+        drive.Drive(self._filer).format_all()
+        self._filer.get.assert_called_once_with('/status/storage/disks')
+
+        expected_param = Object()
+        expected_param.name = self._drive_name
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def _get_drives_param(self):
+        drive_param = Object()
+        drive_param.name = self._drive_name
+        drives = [drive_param]
+        return drives

--- a/tests/ut/test_edge_groups.py
+++ b/tests/ut/test_edge_groups.py
@@ -1,0 +1,23 @@
+from cterasdk.edge import groups
+from tests.ut import base_edge
+
+
+class TestEdgeGroups(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._group_name = 'group'
+
+    def test_get_all_group(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = groups.Groups(self._filer).get()
+        self._filer.get.assert_called_once_with('/config/auth/groups')
+        self.assertEqual(ret, get_response)
+
+    def test_get_group(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = groups.Groups(self._filer).get(self._group_name)
+        self._filer.get.assert_called_once_with('/config/auth/groups/' + self._group_name)
+        self.assertEqual(ret, get_response)

--- a/tests/ut/test_edge_login.py
+++ b/tests/ut/test_edge_login.py
@@ -1,0 +1,49 @@
+from unittest import mock
+
+from cterasdk import exception
+from cterasdk.edge import login
+from tests.ut import base_edge
+
+
+class TestEdgeLogin(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._username = 'admin'
+        self._password = 'password'
+
+    def test_login_success(self):
+        self._init_filer()
+        login.Login(self._filer).login(self._username, self._password)
+        self._filer.form_data.assert_called_once_with('/login', {'username': self._username, 'password': self._password})
+
+    def test_login_failure(self):
+        error_message = "Expected Failure"
+        expected_exception = exception.CTERAException(message=error_message)
+        self._filer.form_data = mock.MagicMock(side_effect=expected_exception)
+        with self.assertRaises(exception.CTERAException) as error:
+            login.Login(self._filer).login(self._username, self._password)
+        self.assertEqual(error_message, error.exception.message)
+
+    def test_logout_success_after_login_success(self):
+        self._init_filer()
+        login.Login(self._filer).login(self._username, self._password)
+        login.Login(self._filer).logout()
+        self._filer.form_data.assert_has_calls(
+            [
+                mock.call('/login', {'username': self._username, 'password': self._password}),
+                mock.call('/logout', {'foo': 'bar'})
+            ]
+        )
+
+    def test_logout_failure_after_login_success(self):
+        self._init_filer()
+        login.Login(self._filer).login(self._username, self._password)
+        self._filer.form_data.assert_called_once_with('/login', {'username': self._username, 'password': self._password})
+        error_message = "Expected Failure"
+        expected_exception = exception.CTERAException(message=error_message)
+        self._filer.form_data = mock.MagicMock(side_effect=expected_exception)
+        with self.assertRaises(exception.CTERAException) as error:
+            login.Login(self._filer).logout()
+        self._filer.form_data.assert_called_once_with('/logout', {'foo': 'bar'})
+        self.assertEqual(error_message, error.exception.message)

--- a/tests/ut/test_edge_mail.py
+++ b/tests/ut/test_edge_mail.py
@@ -16,7 +16,7 @@ class TestEdgeMailServer(base_edge.BaseEdgeTest):
         self._password = 'password'
         self._use_tls = True
 
-    def test_enable_mail_server_default_port_no_auth_no_tls(self):
+    def test_enable_mail_server_default_port_no_auth_with_tls(self):
         get_response = self._get_default_mail_server_config()
         self._init_filer(get_response=get_response)
         mail.Mail(self._filer).enable(self._smtp_server)
@@ -48,6 +48,22 @@ class TestEdgeMailServer(base_edge.BaseEdgeTest):
         expected_param = self._get_mail_server_config(self._default_port, self._username, self._password, self._use_tls)
         actual_param = self._filer.put.call_args[0][1]
         self._assert_equal_objects(expected_param, actual_param)
+
+    def test_enable_mail_server_default_port_no_auth_no_tls(self):
+        get_response = self._get_default_mail_server_config()
+        self._init_filer(get_response=get_response)
+        mail.Mail(self._filer).enable(self._smtp_server, self._default_port, self._username, self._password, False)
+        self._filer.get.assert_called_once_with('/config/logging/alert')
+        self._filer.put.assert_called_once_with('/config/logging/alert', mock.ANY)
+
+        expected_param = self._get_mail_server_config(self._default_port, self._username, self._password, False)
+        actual_param = self._filer.put.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_disable_mail_server(self):
+        self._init_filer()
+        mail.Mail(self._filer).disable()
+        self._filer.put.assert_called_once_with('/config/logging/alert/useCustomServer', False)
 
     def _get_default_mail_server_config(self):
         mail_param = Object()

--- a/tests/ut/test_edge_mail.py
+++ b/tests/ut/test_edge_mail.py
@@ -1,0 +1,71 @@
+from unittest import mock
+
+from cterasdk.edge import mail
+from cterasdk.common import Object
+from tests.ut import base_edge
+
+
+class TestEdgeMailServer(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._smtp_server = 'smtp_server'
+        self._default_port = 25
+        self._custom_port = 486
+        self._username = 'admin'
+        self._password = 'password'
+        self._use_tls = True
+
+    def test_enable_mail_server_default_port_no_auth_no_tls(self):
+        get_response = self._get_default_mail_server_config()
+        self._init_filer(get_response=get_response)
+        mail.Mail(self._filer).enable(self._smtp_server)
+        self._filer.get.assert_called_once_with('/config/logging/alert')
+        self._filer.put.assert_called_once_with('/config/logging/alert', mock.ANY)
+
+        expected_param = self._get_mail_server_config()
+        actual_param = self._filer.put.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_enable_mail_server_custom_port_no_auth_with_tls(self):
+        get_response = self._get_default_mail_server_config()
+        self._init_filer(get_response=get_response)
+        mail.Mail(self._filer).enable(self._smtp_server, self._custom_port)
+        self._filer.get.assert_called_once_with('/config/logging/alert')
+        self._filer.put.assert_called_once_with('/config/logging/alert', mock.ANY)
+
+        expected_param = self._get_mail_server_config(self._custom_port)
+        actual_param = self._filer.put.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_enable_mail_server_default_port_with_auth_with_tls(self):
+        get_response = self._get_default_mail_server_config()
+        self._init_filer(get_response=get_response)
+        mail.Mail(self._filer).enable(self._smtp_server, self._default_port, self._username, self._password, self._use_tls)
+        self._filer.get.assert_called_once_with('/config/logging/alert')
+        self._filer.put.assert_called_once_with('/config/logging/alert', mock.ANY)
+
+        expected_param = self._get_mail_server_config(self._default_port, self._username, self._password, self._use_tls)
+        actual_param = self._filer.put.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def _get_default_mail_server_config(self):
+        mail_param = Object()
+        mail_param.port = self._default_port
+        mail_param.useTLS = self._use_tls
+        return mail_param
+
+    def _get_mail_server_config(self, port=25, username=None, password=None, use_tls=True):
+        mail_param = Object()
+        mail_param.useCustomServer = True
+        mail_param.SMTPServer = self._smtp_server
+        mail_param.port = port
+
+        if username is not None and password is not None:
+            mail_param.useAuth = True
+            mail_param.auth = Object()
+            mail_param.auth.username = username
+            mail_param.auth.password = password
+
+        mail_param.useTLS = use_tls
+        return mail_param

--- a/tests/ut/test_edge_network.py
+++ b/tests/ut/test_edge_network.py
@@ -1,0 +1,173 @@
+from unittest import mock
+
+from cterasdk.edge import network
+from cterasdk.edge import taskmgr
+from cterasdk.edge.enum import Mode
+from cterasdk.common import Object
+from tests.ut import base_edge
+
+
+class TestEdgeNetwork(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._static_ip = Object()
+        self._static_ip.DHCPMode = Mode.Disabled
+        self._static_ip.address = '192.168.0.150'
+        self._static_ip.netmask = '255.255.240.0'
+        self._static_ip.gateway = '192.168.0.1'
+        self._static_ip.autoObtainDNS = False
+        self._static_ip.DNSServer1 = '192.168.0.2'
+        self._static_ip.DNSServer2 = '192.168.0.3'
+
+        self._dhcp_ip = Object()
+        self._dhcp_ip.DHCPMode = Mode.Enabled
+        self._dhcp_ip.address = '10.0.0.1'
+        self._dhcp_ip.netmask = '255.255.255.0'
+        self._dhcp_ip.gateway = '10.0.0.138'
+        self._dhcp_ip.autoObtainDNS = True
+        self._dhcp_ip.DNSServer1 = '10.0.0.2'
+        self._dhcp_ip.DNSServer2 = '8.8.8.8'
+
+        self._task_id = '138'
+        self._tcp_connect_address = 'address'
+        self._tcp_connect_port = 995
+
+    def test_network_status(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = network.Network(self._filer).status()
+        self._filer.get('/status/network/ports/0')
+        self.assertEqual(ret, get_response)
+
+    def test_ifconfig(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = network.Network(self._filer).ifconfig()
+        self._filer.get('/config/network/ports/0')
+        self.assertEqual(ret, get_response)
+
+    def test_ipconfig(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = network.Network(self._filer).ipconfig()
+        self._filer.get('/config/network/ports/0')
+        self.assertEqual(ret, get_response)
+
+    def test_set_static_ip_addr(self):
+        get_response = self._dhcp_ip
+        self._init_filer(get_response=get_response)
+        network.Network(self._filer).set_static_ipaddr(
+            self._static_ip.address,
+            self._static_ip.netmask,
+            self._static_ip.gateway,
+            self._static_ip.DNSServer1,
+            self._static_ip.DNSServer2
+        )
+        self._filer.get.assert_called_once_with('/config/network/ports/0/ip')
+        self._filer.put.assert_called_once_with('/config/network/ports/0/ip', mock.ANY)
+
+        expected_param = self._static_ip
+        actual_param = self._filer.put.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_enable_dhcp(self):
+        get_response = self._static_ip
+        self._init_filer(get_response=get_response)
+        network.Network(self._filer).enable_dhcp()
+        self._filer.get.assert_called_once_with('/config/network/ports/0/ip')
+        self._filer.put.assert_called_once_with('/config/network/ports/0/ip', mock.ANY)
+
+        self._static_ip.DHCPMode = Mode.Enabled
+        self._static_ip.autoObtainDNS = False
+        expected_param = self._static_ip
+        actual_param = self._filer.put.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_set_static_primary_dns_server(self):
+        self._dhcp_ip.secondary_dns_server = None
+        get_response = self._dhcp_ip
+        self._init_filer(get_response=get_response)
+        network.Network(self._filer).set_static_nameserver(self._static_ip.DNSServer1)
+        self._filer.get.assert_called_once_with('/config/network/ports/0/ip')
+        self._filer.put.assert_called_once_with('/config/network/ports/0/ip', mock.ANY)
+
+        self._dhcp_ip.DNSServer1 = self._static_ip.DNSServer1
+        expected_param = self._dhcp_ip
+        actual_param = self._filer.put.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_set_static_primary_and_secondary_dns_servers(self):
+        get_response = self._dhcp_ip
+        self._init_filer(get_response=get_response)
+        network.Network(self._filer).set_static_nameserver(self._static_ip.DNSServer1, self._static_ip.DNSServer2)
+        self._filer.get.assert_called_once_with('/config/network/ports/0/ip')
+        self._filer.put.assert_called_once_with('/config/network/ports/0/ip', mock.ANY)
+
+        self._dhcp_ip.DNSServer1 = self._static_ip.DNSServer1
+        self._dhcp_ip.DNSServer2 = self._static_ip.DNSServer2
+        expected_param = self._dhcp_ip
+        actual_param = self._filer.put.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_tcp_connect_success(self):
+        execute_response = self._task_id
+        self._init_filer(execute_response=execute_response)
+
+        task = Object()
+        task.result = Object()
+        task.result.rc = 'Open'
+        taskmgr.wait = mock.MagicMock(return_value=task)
+
+        ret = network.Network(self._filer).tcp_connect(self._tcp_connect_address, self._tcp_connect_port)
+
+        self._filer.execute.assert_called_once_with('/status/network', 'tcpconnect', mock.ANY)
+        taskmgr.wait.assert_called_once_with(self._filer, self._task_id)
+
+        expected_param = self._get_tcp_connect_object()
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+        self.assertEqual(ret, True)
+
+    def tcp_connect_failure(self):
+        execute_response = self._task_id
+        self._init_filer(execute_response=execute_response)
+
+        task = Object()
+        task.result = Object()
+        task.result.rc = 'BadAddress'
+        taskmgr.wait = mock.MagicMock(return_value=task)
+
+        ret = network.Network(self._filer).tcp_connect(self._tcp_connect_address, self._tcp_connect_port)
+
+        self._filer.execute.assert_called_once_with('/status/network', 'tcpconnect', mock.ANY)
+        taskmgr.wait.assert_called_once_with(self._filer, self._task_id)
+
+        expected_param = self._get_tcp_connect_object()
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+        self.assertEqual(ret, False)
+
+    def tcp_connect_task_error(self):
+        execute_response = self._task_id
+        self._init_filer(execute_response=execute_response)
+        taskmgr.wait = mock.MagicMock(side_effect=taskmgr.TaskError(self._task_id))
+
+        ret = network.Network(self._filer).tcp_connect(self._tcp_connect_address, self._tcp_connect_port)
+
+        self._filer.execute.assert_called_once_with('/status/network', 'tcpconnect', mock.ANY)
+        taskmgr.wait.assert_called_once_with(self._filer, self._task_id)
+
+        expected_param = self._get_tcp_connect_object()
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+        self.assertEqual(ret, False)
+
+    def _get_tcp_connect_object(self):
+        tcp_connect_param = Object()
+        tcp_connect_param.address = self._tcp_connect_address
+        tcp_connect_param.port = self._tcp_connect_port
+        return tcp_connect_param

--- a/tests/ut/test_edge_power.py
+++ b/tests/ut/test_edge_power.py
@@ -1,0 +1,36 @@
+from unittest import mock
+
+from cterasdk.edge import power
+from tests.ut import base_edge
+
+
+class TestEdgePower(base_edge.BaseEdgeTest):
+
+    def test_reboot_wait_false(self):
+        self._init_filer()
+        power.Power(self._filer).reboot(wait=False)
+        self._filer.execute.assert_called_once_with("/status/device", "reboot", None)
+
+    def test_reboot_wait_true(self):
+        self._init_filer()
+        self.patch_call("cterasdk.edge.power.Boot._increment")
+        self._filer.test = mock.MagicMock()
+        power.Power(self._filer).reboot(wait=True)
+        self._filer.execute.assert_called_once_with("/status/device", "reboot", None)
+
+    def test_reset_wait_false(self):
+        self._init_filer()
+        power.Power(self._filer).reset(wait=False)
+        self._filer.execute.assert_called_once_with("/status/device", "reset2default", None)
+
+    def test_reset_wait_true(self):
+        self._init_filer()
+        self.patch_call("cterasdk.edge.power.Boot._increment")
+        self._filer.test = mock.MagicMock()
+        power.Power(self._filer).reset(wait=True)
+        self._filer.execute.assert_called_once_with("/status/device", "reset2default", None)
+
+    def test_shutdown(self):
+        self._init_filer()
+        power.Power(self._filer).shutdown()
+        self._filer.execute.assert_called_once_with("/status/device", "poweroff", None)

--- a/tests/ut/test_edge_shares.py
+++ b/tests/ut/test_edge_shares.py
@@ -1,0 +1,170 @@
+from unittest import mock
+
+from cterasdk import exception
+from cterasdk.edge import shares
+from cterasdk.edge.enum import Acl, ClientSideCaching
+from cterasdk.common import Object
+from tests.ut import base_edge
+
+
+class TestEdgeShares(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._root = '/'
+        self._share_name = 'Accounting'
+        self._share_directory = 'users/Service Account/DATA/Accounting'
+        self._share_volume = 'cloud'
+        self._share_fullpath = '%s/%s' % (self._share_volume, self._share_directory)
+        self._share_acl = [('LG', 'Everyone', 'RO'),
+                           ('LU', 'admin', 'RW'),
+                           ('DG', 'CTERA\\Domain Admins', 'RW'),
+                           ('DU', 'walice@ctera.com', 'RW')]
+
+    def test_get_all_shares(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = shares.Shares(self._filer).get()
+        self._filer.get.assert_called_once_with('/config/fileservices/share')
+        self.assertEqual(ret, get_response)
+
+    def test_get_share(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = shares.Shares(self._filer).get(self._share_name)
+        self._filer.get.assert_called_once_with('/config/fileservices/share/' + self._share_name)
+        self.assertEqual(ret, get_response)
+
+    def test_add_cifs_share_default_config_without_acls(self):
+        execute_response = self._get_list_physical_folders_response_object()
+        self._init_filer(execute_response=execute_response)
+
+        shares.Shares(self._filer).add(self._share_name, self._share_fullpath, [])
+
+        self._filer.execute.assert_called_once_with('/status/fileManager', 'listPhysicalFolders', mock.ANY)
+        expected_param = self._get_list_physical_folders_param()
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+        self._filer.add.assert_called_once_with('/config/fileservices/share', mock.ANY)
+        expected_param = self._get_share_object(acl=[])
+        actual_param = self._filer.add.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_add_cifs_share_default_config_with_acls(self):
+        execute_response = self._get_list_physical_folders_response_object()
+        self._init_filer(execute_response=execute_response)
+
+        shares.Shares(self._filer).add(self._share_name, self._share_fullpath, self._share_acl)
+
+        self._filer.execute.assert_called_once_with('/status/fileManager', 'listPhysicalFolders', mock.ANY)
+        expected_param = self._get_list_physical_folders_param()
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+        self._filer.add.assert_called_once_with('/config/fileservices/share', mock.ANY)  # no verification call param _add_share_acl_rule()
+
+    def test_add_cifs_share_invalid_principal_type(self):
+        execute_response = self._get_list_physical_folders_response_object()
+        self._init_filer(execute_response=execute_response)
+
+        with self.assertRaises(exception.InputError) as error:
+            shares.Shares(self._filer).add(self._share_name, self._share_fullpath, [('Expected Failure', 'Everyone', 'RO')])
+
+        self._filer.execute.assert_called_once_with('/status/fileManager', 'listPhysicalFolders', mock.ANY)
+        expected_param = self._get_list_physical_folders_param()
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+        self.assertEqual('Invalid principal type', error.exception.message)
+
+    def test_add_cifs_share_invalid_permission(self):
+        execute_response = self._get_list_physical_folders_response_object()
+        self._init_filer(execute_response=execute_response)
+
+        with self.assertRaises(exception.InputError) as error:
+            shares.Shares(self._filer).add(self._share_name, self._share_fullpath, [('LG', 'Everyone', 'Expected Failure')])
+
+        self._filer.execute.assert_called_once_with('/status/fileManager', 'listPhysicalFolders', mock.ANY)
+        expected_param = self._get_list_physical_folders_param()
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+        self.assertEqual('Invalid permission', error.exception.message)
+
+    def test_add_share_failure(self):
+        execute_response = self._get_list_physical_folders_response_object()
+        self._init_filer(execute_response=execute_response)
+        self._filer.add = mock.MagicMock(side_effect=exception.CTERAException())
+        with self.assertRaises(exception.CTERAException) as error:
+            shares.Shares(self._filer).add(self._share_name, self._share_fullpath, [])
+
+        self._filer.execute.assert_called_once_with('/status/fileManager', 'listPhysicalFolders', mock.ANY)
+        expected_param = self._get_list_physical_folders_param()
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+        self._filer.add.assert_called_once_with('/config/fileservices/share', mock.ANY)
+        expected_param = self._get_share_object(acl=[])
+        actual_param = self._filer.add.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+        self.assertEqual('Share creation failed', error.exception.message)
+
+    def test_list_physical_folders_input_error(self):
+        execute_response = []
+        self._init_filer(execute_response=execute_response)
+        with self.assertRaises(exception.InputError) as error:
+            shares.Shares(self._filer).add(self._share_name, self._share_fullpath, [])
+
+        self._filer.execute.assert_called_once_with('/status/fileManager', 'listPhysicalFolders', mock.ANY)
+        expected_param = self._get_list_physical_folders_param()
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+        self.assertEqual('Invalid root directory.', error.exception.message)
+
+    def test_delete_share_success(self):
+        self._init_filer()
+        shares.Shares(self._filer).delete(self._share_name)
+        self._filer.delete.assert_called_once_with('/config/fileservices/share/' + self._share_name)
+
+    def test_delete_share_failure(self):
+        self._filer.delete = mock.MagicMock(side_effect=exception.CTERAException())
+        with self.assertRaises(exception.CTERAException) as error:
+            shares.Shares(self._filer).delete(self._share_name)
+        self.assertEqual('Share deletion failed', error.exception.message)
+
+    def _get_share_object(self, directory=None, volume=None, acl=None,  # pylint: disable=too-many-arguments
+                          access=None, csc=None, dir_permissions=None,
+                          comment=None, export_to_afp=False, export_to_ftp=False,
+                          export_to_nfs=False, export_to_pc_agent=False,
+                          export_to_rsync=False, indexed=False):
+        share_param = Object()
+        share_param.name = self._share_name
+        share_param.directory = self._share_directory if directory is None else directory
+        share_param.volume = self._share_volume if volume is None else volume
+        share_param.acl = None if acl is None else acl
+        share_param.access = Acl.WindowsNT if access is None else access
+        share_param.csc = ClientSideCaching.Manual if csc is None else csc
+        share_param.dirPermissions = 777 if dir_permissions is None else dir_permissions
+        share_param.comment = None if comment is None else comment
+        share_param.exportToAFP = False if export_to_afp is None else export_to_afp
+        share_param.exportToFTP = False if export_to_ftp is None else export_to_ftp
+        share_param.exportToNFS = False if export_to_nfs is None else export_to_nfs
+        share_param.exportToPCAgent = False if export_to_pc_agent is None else export_to_pc_agent
+        share_param.exportToRSync = False if export_to_rsync is None else export_to_rsync
+        share_param.indexed = False if indexed is None else indexed
+        return share_param
+
+    def _get_list_physical_folders_param(self):
+        list_physical_folders_param = Object()
+        list_physical_folders_param.path = self._root
+        return list_physical_folders_param
+
+    def _get_list_physical_folders_response_object(self, name=None, fullpath=None):
+        list_physical_folders_response = Object()
+        list_physical_folders_response.name = self._share_volume if name is None else name
+        list_physical_folders_response.type = 'some type'
+        list_physical_folders_response.fullpath = (self._root + self._share_volume) if fullpath is None else fullpath
+        return [list_physical_folders_response]

--- a/tests/ut/test_edge_shell.py
+++ b/tests/ut/test_edge_shell.py
@@ -1,0 +1,37 @@
+from unittest import mock
+
+from cterasdk import exception
+from cterasdk.edge import shell
+from cterasdk.edge import taskmgr
+from cterasdk.common import Object
+from tests.ut import base_edge
+
+
+class TestEdgeShell(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._shell_command = 'cat /proc/meminfo'
+        self._task_id = '138'
+        self._task_result = 'MemTotal: 7778104 kB'
+
+    def test_run_shell_command(self):
+        self._init_filer(execute_response=self._task_id)
+        taskmgr.wait = mock.MagicMock(return_value=self._get_task_manager_result_object())
+        ret = shell.Shell(self._filer).run_command(self._shell_command)
+        self._filer.execute.assert_called_once_with('/config/device', 'bgshell', self._shell_command)
+        self.assertEqual(ret, self._task_result)
+
+    def test_run_shell_command_task_error(self):
+        execute_response = self._task_id
+        self._init_filer(execute_response=execute_response)
+        taskmgr.wait = mock.MagicMock(side_effect=taskmgr.TaskError(self._task_id))
+        with self.assertRaises(exception.CTERAException) as error:
+            shell.Shell(self._filer).run_command(self._shell_command)
+        self.assertEqual('An error occurred while executing task', error.exception.message)
+
+    def _get_task_manager_result_object(self):
+        task_param = Object()
+        task_param.result = Object()
+        task_param.result.result = self._task_result
+        return task_param

--- a/tests/ut/test_edge_sync.py
+++ b/tests/ut/test_edge_sync.py
@@ -1,0 +1,62 @@
+from cterasdk.edge import sync
+from cterasdk.edge.enum import Mode
+from tests.ut import base_edge
+
+
+class TestEdgeSync(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._disable_aio = (False, 0, 0)
+        self._enable_aio = (True, 1, 1)
+
+    def test_cloudsync_status(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = sync.Sync(self._filer).status()
+        self._filer.get.assert_called_once_with('/proc/cloudsync/serviceStatus')
+        self.assertEqual(ret, get_response)
+
+    def test_is_cloudsync_disabled_when_disbaled(self):
+        get_response = Mode.Disabled
+        self._init_filer(get_response=get_response)
+        ret = sync.Sync(self._filer).is_disabled()
+        self._filer.get.assert_called_once_with('/config/cloudsync/mode')
+        self.assertEqual(ret, True)
+
+    def test_is_cloudsync_disabled_when_enabled(self):
+        get_response = Mode.Enabled
+        self._init_filer(get_response=get_response)
+        ret = sync.Sync(self._filer).is_disabled()
+        self._filer.get.assert_called_once_with('/config/cloudsync/mode')
+        self.assertEqual(ret, False)
+
+    def test_is_cloudsync_enabled_when_enabled(self):
+        get_response = Mode.Enabled
+        self._init_filer(get_response=get_response)
+        ret = sync.Sync(self._filer).is_enabled()
+        self._filer.get.assert_called_once_with('/config/cloudsync/mode')
+        self.assertEqual(ret, True)
+
+    def test_is_cloudsync_enabled_when_disabled(self):
+        get_response = Mode.Disabled
+        self._init_filer(get_response=get_response)
+        ret = sync.Sync(self._filer).is_enabled()
+        self._filer.get.assert_called_once_with('/config/cloudsync/mode')
+        self.assertEqual(ret, False)
+
+    def test_suspend_cloudsync(self):
+        self._init_filer()
+        sync.Sync(self._filer).suspend()
+        self._filer.put.assert_called_once_with('/config/cloudsync/mode', Mode.Disabled)
+
+    def test_unsuspend_cloudsync(self):
+        self._init_filer()
+        self.patch_call("cterasdk.edge.sync.track")
+        sync.Sync(self._filer).unsuspend()
+        self._filer.put.assert_called_once_with('/config/cloudsync/mode', Mode.Enabled)
+
+    def test_refresh_cloud_drive_folders(self):
+        self._init_filer()
+        sync.Sync(self._filer).refresh()
+        self._filer.execute.assert_called_once_with('/config/cloudsync/cloudExtender', 'refreshPaths', None)

--- a/tests/ut/test_edge_syslog.py
+++ b/tests/ut/test_edge_syslog.py
@@ -1,0 +1,69 @@
+from unittest import mock
+
+from cterasdk.edge import syslog
+from cterasdk.edge.enum import IPProtocol, Severity, Mode
+from cterasdk.common import Object
+from tests.ut import base_edge
+
+
+class TestEdgeSyslog(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._syslog_server = 'syslog.ctera.local'
+        self._default_syslog_port = 514
+        self._custom_syslog_port = 614
+        self._udp = IPProtocol.UDP
+        self._tcp = IPProtocol.TCP
+        self._default_min_severity = Severity.INFO
+        self._min_severity = Severity.ERROR
+
+    def test_enable_syslog_default_params(self):
+        self._init_filer()
+        syslog.Syslog(self._filer).enable(self._syslog_server)
+        self._filer.put.assert_called_once_with('/config/logging/syslog', mock.ANY)
+
+        expected_param = self._get_syslog_object()
+        actual_param = self._filer.put.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_enable_syslog_custom_port(self):
+        self._init_filer()
+        syslog.Syslog(self._filer).enable(self._syslog_server, self._custom_syslog_port)
+        self._filer.put.assert_called_once_with('/config/logging/syslog', mock.ANY)
+
+        expected_param = self._get_syslog_object(self._custom_syslog_port)
+        actual_param = self._filer.put.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_enable_syslog_custom_port_use_tcp_default_severity(self):
+        self._init_filer()
+        syslog.Syslog(self._filer).enable(self._syslog_server, self._custom_syslog_port, self._tcp)
+        self._filer.put.assert_called_once_with('/config/logging/syslog', mock.ANY)
+
+        expected_param = self._get_syslog_object(self._custom_syslog_port, self._tcp)
+        actual_param = self._filer.put.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_enable_syslog_custom_port_use_tcp_severity_error(self):
+        self._init_filer()
+        syslog.Syslog(self._filer).enable(self._syslog_server, self._custom_syslog_port, self._tcp, self._min_severity)
+        self._filer.put.assert_called_once_with('/config/logging/syslog', mock.ANY)
+
+        expected_param = self._get_syslog_object(self._custom_syslog_port, self._tcp, self._min_severity)
+        actual_param = self._filer.put.call_args[0][1]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_disable_syslog(self):
+        self._init_filer()
+        syslog.Syslog(self._filer).disable()
+        self._filer.put.assert_called_once_with('/config/logging/syslog/mode', Mode.Disabled)
+
+    def _get_syslog_object(self, port=None, protocol=None, min_severity=None):
+        syslog_param = Object()
+        syslog_param.mode = Mode.Enabled
+        syslog_param.server = self._syslog_server
+        syslog_param.port = self._default_syslog_port if port is None else port
+        syslog_param.proto = self._udp if protocol is None else protocol
+        syslog_param.minSeverity = self._default_min_severity if min_severity is None else min_severity
+        return syslog_param

--- a/tests/ut/test_edge_telnet.py
+++ b/tests/ut/test_edge_telnet.py
@@ -1,0 +1,56 @@
+from unittest import mock
+
+from cterasdk import exception
+from cterasdk.edge import telnet
+from cterasdk.common import Object
+from tests.ut import base_edge
+
+
+class TestEdgeTelnet(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._telnet_code = '8a1ab2b'
+
+    def test_enable_telnet_success(self):
+        execute_response = 'OK'
+        self._init_filer(execute_response=execute_response)
+        telnet.Telnet(self._filer).enable(self._telnet_code)
+        self._filer.execute.assert_called_once_with('/config/device', 'startTelnetd', mock.ANY)
+
+        expected_param = self._get_telnet_object()
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_enable_telnet_already_running(self):
+        execute_response = 'telnetd already running'
+        self._init_filer(execute_response=execute_response)
+        telnet.Telnet(self._filer).enable(self._telnet_code)
+        self._filer.execute.assert_called_once_with('/config/device', 'startTelnetd', mock.ANY)
+
+        expected_param = self._get_telnet_object()
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+    def test_enable_telnet_raise(self):
+        execute_response = 'Expected Failure'
+        self._init_filer(execute_response=execute_response)
+        with self.assertRaises(exception.CTERAException) as error:
+            telnet.Telnet(self._filer).enable(self._telnet_code)
+
+        self._filer.execute.assert_called_once_with('/config/device', 'startTelnetd', mock.ANY)
+        expected_param = self._get_telnet_object()
+        actual_param = self._filer.execute.call_args[0][2]
+        self._assert_equal_objects(expected_param, actual_param)
+
+        self.assertEqual('Failed enabling telnet access', error.exception.message)
+
+    def test_disable_telnet(self):
+        self._init_filer()
+        telnet.Telnet(self._filer).disable()
+        self._filer.execute.assert_called_once_with('/config/device', 'stopTelnetd')
+
+    def _get_telnet_object(self):
+        telnet_param = Object()
+        telnet_param.code = self._telnet_code
+        return telnet_param

--- a/tests/ut/test_edge_timezone.py
+++ b/tests/ut/test_edge_timezone.py
@@ -1,0 +1,14 @@
+from cterasdk.edge import timezone
+from tests.ut import base_edge
+
+
+class TestEdgeTimezone(base_edge.BaseEdgeTest):
+
+    def setUp(self):
+        super().setUp()
+        self._timezone = '(GMT-05:00) Eastern Time (US , Canada)'
+
+    def test_set_timezone(self):
+        self._init_filer()
+        timezone.Timezone(self._filer).set_timezone(self._timezone)
+        self._filer.put.assert_called_once_with('/config/time/TimeZone', self._timezone)


### PR DESCRIPTION
* Add RAIDLevel enumerator to edge/enum
* Update edge/array param documentation to RAIDLevel instead of string
* Remove redundant code from edge/telnet
* Update ut/base assert_equal_objects() to support deep comparison of objects
* Add form_data to ut/base_edge mock
* Add unit tests for modules: array, backup, cli, drive, groups, login, mail, network, power, shell, sync (cloudsync), telnet and timezome