### PR TITLE
Add the ability to set existing shares to use win-acls, block file types and disable the first time wizard

### DIFF
--- a/cterasdk/edge/config.py
+++ b/cterasdk/edge/config.py
@@ -39,3 +39,10 @@ class Config(BaseCommand):
         """
         logging.getLogger().info('Configuring device hostname. %s', {'hostname': hostname})
         return self._gateway.put('/config/device/hostname', hostname)
+
+    def disable_wizard(self):
+        """
+        Disable the first time wizard
+        """
+        logging.getLogger().info('Disabling first time wizard')
+        return self._gateway.put('/config/gui/openFirstTimeWizard', False)

--- a/cterasdk/edge/shares.py
+++ b/cterasdk/edge/shares.py
@@ -82,6 +82,29 @@ class Shares(BaseCommand):
             logging.getLogger().error("Share creation failed.")
             raise CTERAException('Share creation failed', error)
 
+    def set_share_winacls(self, name):
+        """
+        Set a network share to use Windows ACL Emulation Mode
+
+        :param str name: The share name
+        """
+        logging.getLogger().error("Updating Windows file sharing access mode. %s", {'share': name, 'access': enum.Acl.WindowsNT})
+        self._gateway.put('/config/fileservices/share/' + name + '/access', enum.Acl.WindowsNT)
+
+    def block_files(self, name, extensions):
+        """
+        Configure a share to block one or more file extensions
+
+        :param str name: The share name
+        :param list[str] extensions: List of file extensions to block
+        """
+        share = self.get(name)
+        if share.access != enum.Acl.WindowsNT:
+            raise CTERAException('Cannot block file types on non Windows-ACL enabled shares', None, share=share.name, access=share.access)
+        logging.getLogger().error("Updating the list of blocked file extensions. %s",
+                                  {'share': name, 'extensions': extensions, 'access': enum.Acl.WindowsNT})
+        self._gateway.put('/config/fileservices/share/' + share.name + '/screenedFileTypes', extensions)
+
     def set_acl(self, name, acl):
         """
         Set a network share's access control entries.

--- a/docs/source/api/cterasdk.core.reports.rst
+++ b/docs/source/api/cterasdk.core.reports.rst
@@ -1,5 +1,5 @@
-cterasdk.core.remote module
-===========================
+cterasdk.core.reports module
+============================
 
 .. automodule:: cterasdk.core.reports
     :members:

--- a/docs/source/api/cterasdk.core.rst
+++ b/docs/source/api/cterasdk.core.rst
@@ -29,6 +29,7 @@ Submodules
    cterasdk.core.login
    cterasdk.core.logs
    cterasdk.core.portals
+   cterasdk.core.reports
    cterasdk.core.query
    cterasdk.core.remote
    cterasdk.core.servers
@@ -36,4 +37,3 @@ Submodules
    cterasdk.core.union
    cterasdk.core.users
    cterasdk.core.zones
-

--- a/docs/source/user_guides/Gateway/Gateway.rst
+++ b/docs/source/user_guides/Gateway/Gateway.rst
@@ -218,6 +218,13 @@ Device Configuration
 
    filer.config.set_location('Jupiter')
 
+.. automethod:: cterasdk.edge.config.Config.disable_wizard
+   :noindex:
+
+.. code-block:: python
+
+   filer.config.disable_wizard()
+
 Storage
 =======
 
@@ -335,6 +342,20 @@ Shares
    """Remove two access control entries from the 'Accounting' share"""
 
    filer.shares.remove_acl('Accounting', [ ('DG', 'CTERA\leadership'), ('DU', 'clark.kent@ctera.com') ])
+
+.. automethod:: cterasdk.edge.shares.Shares.set_share_winacls
+   :noindex:
+
+.. code-block:: python
+
+   filer.shares.set_share_winacls('cloud')
+
+.. automethod:: cterasdk.edge.shares.Shares.block_files
+   :noindex:
+
+.. code-block:: python
+
+   filer.shares.block_files('Accounting', ['exe', 'cmd', 'bat'])
 
 .. automethod:: cterasdk.edge.shares.Shares.delete
    :noindex:

--- a/tests/ut/test_edge_config.py
+++ b/tests/ut/test_edge_config.py
@@ -32,3 +32,10 @@ class TestEdgeConfig(base_edge.BaseEdgeTest):
         ret = config.Config(self._filer).set_location(self._location)
         self._filer.put.assert_called_once_with('/config/device/location', self._location)
         self.assertEqual(ret, self._location)
+
+    def test_disable_first_time_wizard(self):
+        put_response = 'Success'
+        self._init_filer(put_response=put_response)
+        ret = config.Config(self._filer).disable_wizard()
+        self._filer.put.assert_called_once_with('/config/gui/openFirstTimeWizard', False)
+        self.assertEqual(ret, put_response)


### PR DESCRIPTION
## New Functionality
### edge/shares.py
1. Add support for blocking file types **Shares.block_files(name, extensions)**
2. Add support for setting shares to use win-acls **Shares.set_share_winacls(name)**
3. Add respective tests and documentation
### edge/config.py
1. Add support for disabling the first time setup wizard **Config.disable_wizard()**
2. Add respective tests and documentation
## Documentation
1. Register the **reports** module in the **cterasdk.core.rst** file